### PR TITLE
Enforce minimum font size limit for text element on canvas

### DIFF
--- a/assets/src/edit-story/components/canvas/singleSelectionMoveable.js
+++ b/assets/src/edit-story/components/canvas/singleSelectionMoveable.js
@@ -314,7 +314,7 @@ function SingleSelectionMoveable({
           pushTransform(selectedElement.id, frame);
         }
       }}
-      onResize={({ target, direction, width, height, drag }) => {
+      onResize={({ target, direction, width, height, drag, delta }) => {
         let newWidth = width;
         let newHeight = height;
         let updates = null;
@@ -338,19 +338,20 @@ function SingleSelectionMoveable({
             selectedElement,
             direction,
             editorToDataX(newWidth),
-            editorToDataY(newHeight)
+            editorToDataY(newHeight),
+            delta
           );
         }
         if (updates && updates.height) {
           newHeight = dataToEditorY(updates.height);
         }
 
-        target.style.width = `${newWidth}px`;
-        target.style.height = `${newHeight}px`;
+        if (!updates || updates.skipUpdates !== true) {
+          frame.resize = [newWidth, newHeight];
+          frame.updates = updates;
+        }
         frame.direction = direction;
-        frame.resize = [newWidth, newHeight];
         frame.translate = drag.beforeTranslate;
-        frame.updates = updates;
         setTransformStyle(target);
       }}
       onResizeEnd={({ target }) => {

--- a/assets/src/edit-story/elements/text/index.js
+++ b/assets/src/edit-story/elements/text/index.js
@@ -62,6 +62,7 @@ export const resizeRules = {
   diagonal: true,
   minWidth: 20,
   minHeight: 0, // Enforced by min font size
+  minFontSize: 8,
 };
 
 export const panels = [

--- a/assets/src/edit-story/elements/text/updateForResizeEvent.js
+++ b/assets/src/edit-story/elements/text/updateForResizeEvent.js
@@ -22,17 +22,24 @@ import {
   calculateTextHeight,
 } from '../../utils/textMeasurements';
 import { dataPixels } from '../../units';
+import { resizeRules } from './index';
 
-function updateForResizeEvent(element, direction, newWidth, newHeight) {
+function updateForResizeEvent(element, direction, newWidth, newHeight, delta) {
   const isResizingWidth = direction[0] !== 0;
   const isResizingHeight = direction[1] !== 0;
+  const isSizingUp = delta ? delta[0] + delta[1] > 0 : true;
 
   // Vertical or diagonal resizing w/keep ratio.
   if (isResizingHeight) {
+    const fontSize = calculateFitTextFontSize(
+      element,
+      newWidth || element.width,
+      newHeight
+    );
+    const fontSizeInDataPx = dataPixels(fontSize);
     return {
-      fontSize: dataPixels(
-        calculateFitTextFontSize(element, newWidth || element.width, newHeight)
-      ),
+      fontSize: fontSizeInDataPx,
+      skipUpdates: !isSizingUp && fontSizeInDataPx < resizeRules.minFontSize,
     };
   }
 

--- a/assets/src/edit-story/elements/text/updateForResizeEvent.js
+++ b/assets/src/edit-story/elements/text/updateForResizeEvent.js
@@ -24,6 +24,16 @@ import {
 import { dataPixels } from '../../units';
 import { resizeRules } from './index';
 
+/**
+ * Callback used in Moveable resize event
+ *
+ * @param {Element} element The element
+ * @param {Array} direction Moveable direction
+ * @param {number} newWidth New element width
+ * @param {number} newHeight New element height
+ * @param {Array} delta Moveable delta
+ * @return {null|{skipUpdates: boolean, fontSize: number}|{height: number}} Information about properties to update
+ */
 function updateForResizeEvent(element, direction, newWidth, newHeight, delta) {
   const isResizingWidth = direction[0] !== 0;
   const isResizingHeight = direction[1] !== 0;

--- a/assets/src/edit-story/karma/elementTransform.cuj.karma.js
+++ b/assets/src/edit-story/karma/elementTransform.cuj.karma.js
@@ -65,9 +65,7 @@ describe('CUJ: Creator can Transform an Element', () => {
     describe('Action: Resize', () => {
       it('it should not allow resizing text below 8px font size', async () => {
         // Test that resize handle exists in edit mode.
-        const bottomRightResizeHandle = fixture.container.querySelector(
-          '.moveable-control.moveable-se'
-        );
+        const bottomRightResizeHandle = fixture.editor.canvas.moveable.resizeSE;
         expect(bottomRightResizeHandle).toBeDefined();
 
         expect(
@@ -76,7 +74,7 @@ describe('CUJ: Creator can Transform an Element', () => {
         await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
           moveRel(bottomRightResizeHandle, 1, 1),
           down(),
-          moveBy(-80, -50),
+          moveBy(-95, -95),
           up(),
         ]);
         expect(
@@ -95,9 +93,7 @@ describe('CUJ: Creator can Transform an Element', () => {
 
       it('it should allow resizing in text edit mode', async () => {
         // Test that resize handle exists in edit mode.
-        const rightResizeHandle = fixture.container.querySelector(
-          '.moveable-control.moveable-e'
-        );
+        const rightResizeHandle = fixture.editor.canvas.moveable.resizeE;
         expect(rightResizeHandle).toBeDefined();
 
         const widthBefore = window.getComputedStyle(frame).width;
@@ -115,9 +111,7 @@ describe('CUJ: Creator can Transform an Element', () => {
     describe('Action: Rotate', () => {
       it('it should allow rotating in text edit mode', async () => {
         // Test that rotation handle exists in edit mode.
-        const rotationHandle = fixture.container.querySelector(
-          '.moveable-rotation-line .moveable-control'
-        );
+        const rotationHandle = fixture.editor.canvas.moveable.rotate;
         expect(rotationHandle).toBeDefined();
 
         const elementBefore = await getSelectedElement();

--- a/assets/src/edit-story/karma/elementTransform.cuj.karma.js
+++ b/assets/src/edit-story/karma/elementTransform.cuj.karma.js
@@ -63,6 +63,36 @@ describe('CUJ: Creator can Transform an Element', () => {
     });
 
     describe('Action: Resize', () => {
+      it('it should not allow resizing text below 8px font size', async () => {
+        // Test that resize handle exists in edit mode.
+        const bottomRightResizeHandle = fixture.container.querySelector(
+          '.moveable-control.moveable-se'
+        );
+        expect(bottomRightResizeHandle).toBeDefined();
+
+        expect(
+          fixture.editor.inspector.designPanel.textStyle.fontSize.value
+        ).toBe('36');
+        await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+          moveRel(bottomRightResizeHandle, 1, 1),
+          down(),
+          moveBy(-80, -50),
+          up(),
+        ]);
+        expect(
+          fixture.editor.inspector.designPanel.textStyle.fontSize.value
+        ).toBe('8');
+        await fixture.events.mouse.seq(({ moveRel, moveBy, down, up }) => [
+          moveRel(bottomRightResizeHandle, 1, 1),
+          down(),
+          moveBy(-20, -20),
+          up(),
+        ]);
+        expect(
+          fixture.editor.inspector.designPanel.textStyle.fontSize.value
+        ).toBe('8');
+      });
+
       it('it should allow resizing in text edit mode', async () => {
         // Test that resize handle exists in edit mode.
         const rightResizeHandle = fixture.container.querySelector(

--- a/assets/src/edit-story/karma/fixture/containers/canvas.js
+++ b/assets/src/edit-story/karma/fixture/containers/canvas.js
@@ -28,6 +28,14 @@ export class Canvas extends Container {
     super(node, path);
   }
 
+  get moveable() {
+    return this._get(
+      this.node.querySelector(`.moveable-control-box.default-moveable`),
+      `moveable`,
+      Moveable
+    );
+  }
+
   get displayLayer() {
     return this._get(
       this.getByRole('region', { name: 'Display' }),
@@ -145,5 +153,26 @@ class Frame extends Container {
 
   get textContentHTML() {
     return this.node.querySelector('p')?.innerHTML;
+  }
+}
+
+/**
+ * Moveable box.
+ */
+class Moveable extends Container {
+  constructor(node, path) {
+    super(node, path);
+  }
+
+  get resizeSE() {
+    return this.node.querySelector('.moveable-se');
+  }
+
+  get resizeE() {
+    return this.node.querySelector('.moveable-e');
+  }
+
+  get rotate() {
+    return this.node.querySelector('.moveable-rotation');
   }
 }

--- a/assets/src/edit-story/karma/fixture/containers/designPanel/textStyle.js
+++ b/assets/src/edit-story/karma/fixture/containers/designPanel/textStyle.js
@@ -77,8 +77,12 @@ export class TextStyle extends AbstractPanel {
     );
   }
 
+  get fontSize() {
+    return this.getByRole('textbox', { name: /Font size/ });
+  }
+
   // @todo: add remaining input options:
-  // * font family and size
+  // * font family
   // * justify toggles
   // * fill style
   // * background color


### PR DESCRIPTION
## Summary

The minimum font size limit (currently 8px) is now enforced on the canvas too (when you use handles to resize).

## Relevant Technical Choices

The implementation is a little bit different than the one for other elements, you will see no jump when resizing up from <8px font. If you are below 8px (because you resized down a group of elements - this is the only way, we don't enforce the limit there) you can upscale smoothly, but you cannot downscale. Something similar can be implemented for other elements.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!-- Please describe your changes. -->

## Testing Instructions

1. Try to downscale a single text element, it shouldn't go below 8px font size

1. Downscale a group of text elements so that any of them will go below 8px
2. Downscale/upscale the smallest text (the one that is <8px). It should only upscale.

---

<!-- Please reference the issue(s) this PR addresses. -->

Fixes https://github.com/google/web-stories-wp/issues/2878
