### PR TITLE
E2E Tests: Make widget block test more robust

### DIFF
--- a/packages/e2e-tests/src/specs/wordpress/blockWidget.js
+++ b/packages/e2e-tests/src/specs/wordpress/blockWidget.js
@@ -29,7 +29,7 @@ import {
 
 describe('Web Stories Widget Block', () => {
   minWPVersionRequired('5.8');
-  beforeEach(async () => {
+  beforeAll(async () => {
     await deleteWidgets();
   });
   afterEach(async () => {

--- a/packages/e2e-tests/src/specs/wordpress/blockWidget.js
+++ b/packages/e2e-tests/src/specs/wordpress/blockWidget.js
@@ -32,7 +32,7 @@ describe('Web Stories Widget Block', () => {
   beforeEach(async () => {
     await deleteWidgets();
   });
-  afterAll(async () => {
+  afterEach(async () => {
     await deleteWidgets();
   });
 
@@ -101,6 +101,7 @@ describe('Web Stories Widget Block', () => {
     await visitBlockWidgetScreen();
     const selector = '.wp-block-legacy-widget';
 
+    await page.waitForSelector(selector);
     await expect(page).toMatchElement(selector);
     await expect(page).toClick(selector);
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Improve block widget e2e tests, but cleaning data and waiting a little longer. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [ ] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
