### PR TITLE
Removed all references to backdrop blur

### DIFF
--- a/packages/story-editor/src/components/canvas/useInsertTextSet.js
+++ b/packages/story-editor/src/components/canvas/useInsertTextSet.js
@@ -135,7 +135,6 @@ function useInsertTextSet() {
             backgroundColor: {
               color: preferredScrimColor,
             },
-            backdropBlur: 4,
             type: 'shape',
           };
           addedElements.push(insertElement(ELEMENT_TYPES.SHAPE, scrim));

--- a/packages/story-editor/src/elements/shape/display.js
+++ b/packages/story-editor/src/elements/shape/display.js
@@ -42,8 +42,6 @@ const Element = styled.div`
   ${elementFillContent}
   ${elementWithBackgroundColor}
   ${elementWithBorder}
-  ${({ backdropBlur }) =>
-    backdropBlur && `backdrop-filter: blur(${backdropBlur}px)`}
 `;
 
 function ShapeDisplay({ element, previewMode }) {
@@ -55,7 +53,6 @@ function ShapeDisplay({ element, previewMode }) {
     borderRadius,
     width: elementWidth,
     height: elementHeight,
-    backdropBlur,
   } = element;
 
   const { dataToEditorX } = useUnits((state) => ({
@@ -97,7 +94,6 @@ function ShapeDisplay({ element, previewMode }) {
       borderRadius={borderRadius}
       width={elementWidth}
       height={elementHeight}
-      backdropBlur={backdropBlur}
       border={getResponsiveBorder(border, previewMode, dataToEditorX)}
     />
   );

--- a/packages/story-editor/src/elements/shape/output.js
+++ b/packages/story-editor/src/elements/shape/output.js
@@ -29,23 +29,13 @@ import StoryPropTypes from '../../types';
  * @param {Object<*>} props Props.
  * @return {*} Rendered component.
  */
-function ShapeOutput({
-  element: { backgroundColor, isDefaultBackground, backdropBlur },
-}) {
+function ShapeOutput({ element: { backgroundColor, isDefaultBackground } }) {
   const style = isDefaultBackground
     ? null
     : generatePatternStyles(backgroundColor);
-  const backdropFilters = backdropBlur
-    ? { backdropFilter: `blur(${backdropBlur}px)` }
-    : null;
   // willChange added by #7380 https://github.com/google/web-stories-wp/pull/7380
   // to prevent issues with the border radius on shapes not being respected when animated
-  return (
-    <div
-      className="fill"
-      style={{ ...style, willChange: 'transform', ...backdropFilters }}
-    />
-  );
+  return <div className="fill" style={{ ...style, willChange: 'transform' }} />;
 }
 
 ShapeOutput.propTypes = {


### PR DESCRIPTION
## Context

Removed the background blur introduced in #7995.

## User-facing changes

| Background | With blur | Without blur |
|-|-|-|
| ![Screen Shot 2021-08-26 at 14 16 48](https://user-images.githubusercontent.com/637548/131015366-94ff05b2-cdf3-4369-927d-5711439060cf.png) | ![Screen Shot 2021-08-26 at 14 17 07](https://user-images.githubusercontent.com/637548/131015364-46128f40-30bd-4613-9011-4f82db160be4.png) | ![Screen Shot 2021-08-26 at 14 17 22](https://user-images.githubusercontent.com/637548/131015360-f16de36e-b00b-493b-8cdd-563fe56b6cae.png) |

## Testing Instructions

This PR can be tested by following these steps:

1. Add a multi-colored background
2. Insert a text set with only a single color text
3. Observe that the text set is inserted with a scrim behind it
4. Observe that said scrim does not cause the background to blur

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #8819
