### PR TITLE
Prefix custom REST API fields

### DIFF
--- a/includes/Integrations/Jetpack.php
+++ b/includes/Integrations/Jetpack.php
@@ -241,7 +241,7 @@ class Jetpack extends Service_Base {
 	 */
 	protected function add_extra_data( array $data, $videopress_key ): array {
 		// Make video as optimized.
-		$data['media_source'] = 'video-optimization';
+		$data[ $this->media_source_taxonomy::MEDIA_SOURCE_KEY ] = 'video-optimization';
 
 		if ( isset( $data['media_details']['videopress'] ) ) {
 			$videopress = $data['media_details']['videopress'];

--- a/includes/Media/Media_Source_Taxonomy.php
+++ b/includes/Media/Media_Source_Taxonomy.php
@@ -55,6 +55,13 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 	protected $taxonomy_post_type = 'attachment';
 
 	/**
+	 * Media Source key.
+	 *
+	 * @var string
+	 */
+	const MEDIA_SOURCE_KEY = 'web_stories_media_source';
+
+	/**
 	 * Init.
 	 *
 	 * @since 1.10.0
@@ -104,7 +111,7 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 		// Custom field, as built in term update require term id and not slug.
 		register_rest_field(
 			$this->taxonomy_post_type,
-			'media_source',
+			self::MEDIA_SOURCE_KEY,
 			[
 
 				'get_callback'    => [ $this, 'get_callback_media_source' ],
@@ -140,7 +147,7 @@ class Media_Source_Taxonomy extends Taxonomy_Base {
 		if ( ! is_array( $response ) ) {
 			return $response;
 		}
-		$response['media_source'] = $this->get_callback_media_source( $response );
+		$response[ self::MEDIA_SOURCE_KEY ] = $this->get_callback_media_source( $response );
 
 		return $response;
 	}

--- a/includes/templates/admin/edit-story.php
+++ b/includes/templates/admin/edit-story.php
@@ -90,7 +90,7 @@ $preload_paths = [
 						'alt_text',
 						'source_url',
 						'meta',
-						'media_source',
+						'web_stories_media_source',
 						'is_muted',
 						// _web_stories_envelope will add these fields, we need them too.
 						'body',

--- a/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
@@ -143,7 +143,7 @@ describe('useProcessMedia', () => {
           'http://www.google.com/foo.gif'
         );
         expect(updateMedia).toHaveBeenCalledWith(123, {
-          media_source: 'source-video',
+          web_stories_media_source: 'source-video',
           meta: {
             web_stories_optimized_id: 2,
           },
@@ -267,7 +267,7 @@ describe('useProcessMedia', () => {
           'http://www.google.com/foo.gif'
         );
         expect(updateMedia).toHaveBeenCalledWith(123, {
-          media_source: 'source-image',
+          web_stories_media_source: 'source-image',
           meta: {
             web_stories_optimized_id: 2,
           },

--- a/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
+++ b/packages/story-editor/src/app/media/utils/useMediaUploadQueue/index.js
@@ -241,7 +241,7 @@ function useMediaUploadQueue() {
             try {
               newFile = await convertGifToVideo(file);
               finishTranscoding({ id, file: newFile });
-              additionalData.media_source = 'gif-conversion';
+              additionalData.web_stories_media_source = 'gif-conversion';
               additionalData.is_muted = true;
             } catch (error) {
               // Cancel uploading if there were any errors.
@@ -299,7 +299,7 @@ function useMediaUploadQueue() {
               try {
                 newFile = await transcodeVideo(file);
                 finishTranscoding({ id, file: newFile });
-                additionalData.media_source = 'video-optimization';
+                additionalData.web_stories_media_source = 'video-optimization';
               } catch (error) {
                 // Cancel uploading if there were any errors.
                 cancelUploading({ id, error });

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -78,7 +78,7 @@ function useProcessMedia({
   const updateOldTranscodedObject = useCallback(
     (oldId, newId, mediaSource) => {
       updateMedia(oldId, {
-        media_source: mediaSource,
+        web_stories_media_source: mediaSource,
         meta: {
           web_stories_optimized_id: newId,
         },
@@ -255,7 +255,7 @@ function useProcessMedia({
           additionalData: {
             is_muted: oldResource.isMuted,
             original_id: oldResource.id,
-            media_source: oldResource?.isOptimized
+            web_stories_media_source: oldResource?.isOptimized
               ? 'video-optimization'
               : 'editor',
           },
@@ -346,7 +346,7 @@ function useProcessMedia({
           onUploadProgress,
           additionalData: {
             original_id: oldResource.id,
-            media_source: oldResource?.isOptimized
+            web_stories_media_source: oldResource?.isOptimized
               ? 'video-optimization'
               : 'editor',
           },

--- a/packages/story-editor/src/app/media/utils/useUploadVideoFrame.js
+++ b/packages/story-editor/src/app/media/utils/useUploadVideoFrame.js
@@ -76,7 +76,7 @@ function useUploadVideoFrame({ updateMediaElement }) {
 
       const resource = await uploadFile(posterFile, {
         post: id,
-        media_source: 'poster-generation',
+        web_stories_media_source: 'poster-generation',
       });
       const {
         id: posterId,

--- a/packages/story-editor/src/app/uploader/useUploader.js
+++ b/packages/story-editor/src/app/uploader/useUploader.js
@@ -153,7 +153,7 @@ function useUploader() {
       const _additionalData = {
         post: storyId,
         alt_text: getFileName(file),
-        media_source: 'editor',
+        web_stories_media_source: 'editor',
         ...additionalData,
       };
 

--- a/packages/wp-story-editor/src/api/constants/index.js
+++ b/packages/wp-story-editor/src/api/constants/index.js
@@ -46,7 +46,7 @@ export const MEDIA_FIELDS = [
   'alt_text',
   'source_url',
   'meta',
-  'media_source',
+  'web_stories_media_source',
   'is_muted',
   // _web_stories_envelope will add these fields, we need them too.
   'body',

--- a/packages/wp-story-editor/src/api/test/_utils.js
+++ b/packages/wp-story-editor/src/api/test/_utils.js
@@ -50,7 +50,7 @@ export const GET_MEDIA_RESPONSE_BODY = [
     web_story_media_source: [2],
     permalink_template: 'http://wp.local/?attachment_id=274',
     generated_slug: 'IMAGE',
-    media_source: 'editor',
+    web_stories_media_source: 'editor',
     featured_media_src: [],
     description: {
       raw: '',

--- a/packages/wp-story-editor/src/api/utils/getResourceFromAttachment.js
+++ b/packages/wp-story-editor/src/api/utils/getResourceFromAttachment.js
@@ -43,7 +43,7 @@ import {
  * @property {number} featured_media ID of the media item's poster ID.
  * @property {string} alt_text Alt text.
  * @property {string} source_url Media URL.
- * @property {string} media_source Media source.
+ * @property {string} web_stories_media_source Media source.
  * @property {MediaDetails} media_details Media details.
  */
 
@@ -87,7 +87,7 @@ function getVideoResourceFromAttachment(attachment) {
     is_muted: isMuted,
     alt_text: alt,
     source_url: src,
-    media_source: mediaSource,
+    web_stories_media_source: mediaSource,
     meta: { web_stories_trim_data: trimData },
   } = attachment;
 
@@ -166,7 +166,8 @@ function getGifResourceFromAttachment(attachment) {
  * @return {import('./createResource').Resource} Resource object.
  */
 function getResourceFromAttachment(attachment) {
-  const { mime_type: mimeType, media_source: mediaSource } = attachment;
+  const { mime_type: mimeType, web_stories_media_source: mediaSource } =
+    attachment;
 
   if ('gif-conversion' === mediaSource) {
     return getGifResourceFromAttachment(attachment);

--- a/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/useMediaPicker.js
+++ b/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/useMediaPicker.js
@@ -85,7 +85,7 @@ function useMediaPicker({
       // Video poster generation for newly added videos is done in <MediaPane>.
       wp.Uploader.prototype.success = ({ attributes }) => {
         updateMedia(attributes.id, {
-          media_source: 'editor',
+          web_stories_media_source: 'editor',
           alt_text: attributes.alt || attributes.title,
         });
       };
@@ -224,7 +224,10 @@ function useMediaPicker({
       fileFrame.once('cropped', (attachment) => {
         if (attachment?.id) {
           const alt_text = attachment.alt || attachment.title;
-          updateMedia(attachment.id, { media_source: 'editor', alt_text });
+          updateMedia(attachment.id, {
+            web_stories_media_source: 'editor',
+            alt_text,
+          });
           attachment.alt = alt_text;
         }
         onSelect(getResourceFromMediaPicker(attachment));

--- a/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/utils/getResourceFromMediaPicker.js
+++ b/packages/wp-story-editor/src/components/mediaUpload/mediaPicker/utils/getResourceFromMediaPicker.js
@@ -47,7 +47,7 @@ const getResourceFromMediaPicker = (mediaPickerEl) => {
       length_formatted: lengthFormatted,
       sizes,
     },
-    media_source: mediaSource,
+    web_stories_media_source: mediaSource,
     is_muted: isMuted,
     trim_data: trimData,
   } = mediaPickerEl;

--- a/tests/phpunit/integration/tests/Integrations/Jetpack.php
+++ b/tests/phpunit/integration/tests/Integrations/Jetpack.php
@@ -197,10 +197,16 @@ class Jetpack extends TestCase {
 		$allowed_mime_types[] = $jetpack::VIDEOPRESS_MIME_TYPE;
 		$args                 = [ 'post_mime_type' => $allowed_mime_types ];
 		$jetpack->filter_ajax_query_attachments_args( $args );
-		$this->assertSame( 15, has_filter( 'wp_prepare_attachment_for_js', [
-			$jetpack,
-			'filter_admin_ajax_response'
-		] ) );
+		$this->assertSame(
+			15,
+			has_filter(
+				'wp_prepare_attachment_for_js',
+				[
+					$jetpack,
+					'filter_admin_ajax_response',
+				] 
+			) 
+		);
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Integrations/Jetpack.php
+++ b/tests/phpunit/integration/tests/Integrations/Jetpack.php
@@ -105,8 +105,8 @@ class Jetpack extends TestCase {
 		$this->assertArrayHasKey( 'mime_type', $data );
 		$this->assertSame( $data['mime_type'], 'video/mp4' );
 
-		$this->assertArrayHasKey( 'media_source', $data );
-		$this->assertSame( $data['media_source'], 'video-optimization' );
+		$this->assertArrayHasKey( $media_source::MEDIA_SOURCE_KEY, $data );
+		$this->assertSame( $data[ $media_source::MEDIA_SOURCE_KEY ], 'video-optimization' );
 
 		$this->assertArrayHasKey( 'source_url', $data );
 		$this->assertSame( $data['source_url'], self::ATTACHMENT_URL );
@@ -171,8 +171,8 @@ class Jetpack extends TestCase {
 		$this->assertArrayHasKey( 'subtype', $data );
 		$this->assertSame( $data['subtype'], 'mp4' );
 
-		$this->assertArrayHasKey( 'media_source', $data );
-		$this->assertSame( $data['media_source'], 'video-optimization' );
+		$this->assertArrayHasKey( $media_source::MEDIA_SOURCE_KEY, $data );
+		$this->assertSame( $data[ $media_source::MEDIA_SOURCE_KEY ], 'video-optimization' );
 
 		$this->assertArrayHasKey( 'url', $data );
 		$this->assertSame( $data['url'], self::ATTACHMENT_URL );
@@ -197,7 +197,10 @@ class Jetpack extends TestCase {
 		$allowed_mime_types[] = $jetpack::VIDEOPRESS_MIME_TYPE;
 		$args                 = [ 'post_mime_type' => $allowed_mime_types ];
 		$jetpack->filter_ajax_query_attachments_args( $args );
-		$this->assertSame( 15, has_filter( 'wp_prepare_attachment_for_js', [ $jetpack, 'filter_admin_ajax_response' ] ) );
+		$this->assertSame( 15, has_filter( 'wp_prepare_attachment_for_js', [
+			$jetpack,
+			'filter_admin_ajax_response'
+		] ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
+++ b/tests/phpunit/integration/tests/Media/Media_Source_Taxonomy.php
@@ -118,8 +118,8 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertArrayHasKey( 'media_source', $data );
-		$this->assertEquals( 'editor', $data['media_source'] );
+		$this->assertArrayHasKey( $this->instance::MEDIA_SOURCE_KEY, $data );
+		$this->assertEquals( 'editor', $data[ $this->instance::MEDIA_SOURCE_KEY ] );
 	}
 
 	/**
@@ -165,17 +165,17 @@ class Media_Source_Taxonomy extends DependencyInjectedTestCase {
 
 		$this->assertEqualSets(
 			[
-				'type'         => 'image',
-				'media_source' => '',
-				'id'           => $poster_attachment_id,
-				'url'          => wp_get_attachment_url( $poster_attachment_id ),
+				'type'                     => 'image',
+				'web_stories_media_source' => '',
+				'id'                       => $poster_attachment_id,
+				'url'                      => wp_get_attachment_url( $poster_attachment_id ),
 
 			],
 			$image
 		);
 
-		$this->assertArrayHasKey( 'media_source', $image );
-		$this->assertArrayHasKey( 'media_source', $video );
+		$this->assertArrayHasKey( $this->instance::MEDIA_SOURCE_KEY, $image );
+		$this->assertArrayHasKey( $this->instance::MEDIA_SOURCE_KEY, $video );
 	}
 
 	/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

To prevent this incompatibility, all our REST API fields that we register should ideally be prefixed with web_stories.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

To reproduce the issue I was debugging:

1. Activate the official Unsplash plugin
2. Activate the Web Stories plugin
3. Try to upload media in the editor


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9290
