### PR TITLE
Taxonomy: Add placeholder text and update heading level

### DIFF
--- a/packages/story-editor/src/components/form/hierarchical/index.js
+++ b/packages/story-editor/src/components/form/hierarchical/index.js
@@ -26,7 +26,7 @@ import {
   THEME_CONSTANTS,
   useLiveRegion,
 } from '@web-stories-wp/design-system';
-import { _n, sprintf } from '@web-stories-wp/i18n';
+import { _n, sprintf, __ } from '@web-stories-wp/i18n';
 import {
   useCallback,
   useDebouncedCallback,
@@ -202,6 +202,7 @@ const HierarchicalInput = ({
         onChange={handleInputChange}
         label={label}
         type="search"
+        placeholder={__('search', 'web-stories')}
         {...inputProps}
       />
       {showOptionArea && (

--- a/packages/story-editor/src/components/form/hierarchical/index.js
+++ b/packages/story-editor/src/components/form/hierarchical/index.js
@@ -202,7 +202,7 @@ const HierarchicalInput = ({
         onChange={handleInputChange}
         label={label}
         type="search"
-        placeholder={__('search', 'web-stories')}
+        placeholder={__('Search', 'web-stories')}
         {...inputProps}
       />
       {showOptionArea && (

--- a/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
@@ -175,9 +175,7 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
         </Tags.Description>
         {mostUsed.length > 0 && (
           <WordCloud.Wrapper data-testid={`${taxonomy.slug}-most-used`}>
-            <WordCloud.Heading>
-              {__('Most Used', 'web-stories')}
-            </WordCloud.Heading>
+            <WordCloud.Heading>{taxonomy.labels.most_used}</WordCloud.Heading>
             <WordCloud.List>
               {mostUsed.map((term, i) => (
                 <WordCloud.ListItem key={term.id}>

--- a/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
@@ -33,12 +33,7 @@ import Tags, { deepEquals } from '../../../form/tags';
 import cleanForSlug from '../../../../utils/cleanForSlug';
 import { useTaxonomy } from '../../../../app/taxonomy';
 import { useHistory } from '../../../../app';
-import {
-  ContentHeading,
-  TaxonomyPropType,
-  WordCloud,
-  SiblingBorder,
-} from './shared';
+import { ContentHeading, TaxonomyPropType, WordCloud } from './shared';
 
 function FlatTermSelector({ taxonomy, canCreateTerms }) {
   const [mostUsed, setMostUsed] = useState([]);
@@ -152,7 +147,7 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
   }, [taxonomy, addSearchResultsToCache]);
 
   return (
-    <SiblingBorder>
+    <>
       <ContentHeading>{taxonomy.labels.name}</ContentHeading>
       <div key={taxonomy.slug}>
         <Tags.Label htmlFor={`${taxonomy.slug}-input`}>
@@ -203,7 +198,7 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
           </WordCloud.Wrapper>
         )}
       </div>
-    </SiblingBorder>
+    </>
   );
 }
 

--- a/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
@@ -33,7 +33,12 @@ import Tags, { deepEquals } from '../../../form/tags';
 import cleanForSlug from '../../../../utils/cleanForSlug';
 import { useTaxonomy } from '../../../../app/taxonomy';
 import { useHistory } from '../../../../app';
-import { ContentHeading, TaxonomyPropType, WordCloud } from './shared';
+import {
+  ContentHeading,
+  TaxonomyPropType,
+  WordCloud,
+  SiblingBorder,
+} from './shared';
 
 function FlatTermSelector({ taxonomy, canCreateTerms }) {
   const [mostUsed, setMostUsed] = useState([]);
@@ -147,7 +152,7 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
   }, [taxonomy, addSearchResultsToCache]);
 
   return (
-    <>
+    <SiblingBorder>
       <ContentHeading>{taxonomy.labels.name}</ContentHeading>
       <div key={taxonomy.slug}>
         <Tags.Label htmlFor={`${taxonomy.slug}-input`}>
@@ -200,7 +205,7 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
           </WordCloud.Wrapper>
         )}
       </div>
-    </>
+    </SiblingBorder>
   );
 }
 

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -45,12 +45,7 @@ import { v4 as uuidv4 } from 'uuid';
  */
 import { HierarchicalInput } from '../../../form';
 import { useTaxonomy } from '../../../../app/taxonomy';
-import {
-  ContentHeading,
-  TaxonomyPropType,
-  LinkButton,
-  SiblingBorder,
-} from './shared';
+import { ContentHeading, TaxonomyPropType, LinkButton } from './shared';
 
 const NO_PARENT_VALUE = 'NO_PARENT_VALUE';
 
@@ -235,66 +230,62 @@ function HierarchicalTermSelector({
   }, [toggleFocus]);
 
   return (
-    <SiblingBorder>
-      <ContentArea>
-        <ContentHeading>{taxonomy.labels.name}</ContentHeading>
-        <HierarchicalInput
-          label={taxonomy.labels.search_items}
-          options={categories}
-          onChange={handleClickCategory}
-          noOptionsText={taxonomy.labels?.not_found}
-        />
-        {canCreateTerms ? (
-          <>
-            {!showAddNewCategory && (
-              <LinkButton
-                ref={toggleRef}
-                aria-expanded={false}
-                onClick={handleToggleNewCategory}
-              >
-                {taxonomy.labels.add_new_item}
-              </LinkButton>
-            )}
-            {showAddNewCategory ? (
-              <AddNewCategoryForm ref={formRef} onSubmit={handleSubmit}>
-                <Input
-                  autoFocus
-                  name={taxonomy.labels.new_item_name}
-                  label={taxonomy.labels.new_item_name}
-                  value={newCategoryName}
-                  onChange={handleChangeNewCategoryName}
-                  hasFocus={hasFocus}
-                />
-                <Label htmlFor={dropdownId}>
-                  {taxonomy.labels.parent_item}
-                </Label>
-                <DropDown
-                  id={dropdownId}
-                  ariaLabel={taxonomy.labels.parent_item}
-                  options={dropdownCategories}
-                  selectedValue={selectedParent}
-                  onMenuItemClick={handleParentSelect}
-                />
-                <ButtonContainer>
-                  <AddNewCategoryButton
-                    disabled={!newCategoryName.length}
-                    type="submit"
-                  >
-                    {taxonomy.labels.add_new_item}
-                  </AddNewCategoryButton>
-                  <AddNewCategoryButton
-                    aria-expanded
-                    onClick={handleToggleNewCategory}
-                  >
-                    {__('Cancel', 'web-stories')}
-                  </AddNewCategoryButton>
-                </ButtonContainer>
-              </AddNewCategoryForm>
-            ) : null}
-          </>
-        ) : null}
-      </ContentArea>
-    </SiblingBorder>
+    <ContentArea>
+      <ContentHeading>{taxonomy.labels.name}</ContentHeading>
+      <HierarchicalInput
+        label={taxonomy.labels.search_items}
+        options={categories}
+        onChange={handleClickCategory}
+        noOptionsText={taxonomy.labels?.not_found}
+      />
+      {canCreateTerms ? (
+        <>
+          {!showAddNewCategory && (
+            <LinkButton
+              ref={toggleRef}
+              aria-expanded={false}
+              onClick={handleToggleNewCategory}
+            >
+              {taxonomy.labels.add_new_item}
+            </LinkButton>
+          )}
+          {showAddNewCategory ? (
+            <AddNewCategoryForm ref={formRef} onSubmit={handleSubmit}>
+              <Input
+                autoFocus
+                name={taxonomy.labels.new_item_name}
+                label={taxonomy.labels.new_item_name}
+                value={newCategoryName}
+                onChange={handleChangeNewCategoryName}
+                hasFocus={hasFocus}
+              />
+              <Label htmlFor={dropdownId}>{taxonomy.labels.parent_item}</Label>
+              <DropDown
+                id={dropdownId}
+                ariaLabel={taxonomy.labels.parent_item}
+                options={dropdownCategories}
+                selectedValue={selectedParent}
+                onMenuItemClick={handleParentSelect}
+              />
+              <ButtonContainer>
+                <AddNewCategoryButton
+                  disabled={!newCategoryName.length}
+                  type="submit"
+                >
+                  {taxonomy.labels.add_new_item}
+                </AddNewCategoryButton>
+                <AddNewCategoryButton
+                  aria-expanded
+                  onClick={handleToggleNewCategory}
+                >
+                  {__('Cancel', 'web-stories')}
+                </AddNewCategoryButton>
+              </ButtonContainer>
+            </AddNewCategoryForm>
+          ) : null}
+        </>
+      ) : null}
+    </ContentArea>
   );
 }
 

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -45,7 +45,12 @@ import { v4 as uuidv4 } from 'uuid';
  */
 import { HierarchicalInput } from '../../../form';
 import { useTaxonomy } from '../../../../app/taxonomy';
-import { ContentHeading, TaxonomyPropType, LinkButton } from './shared';
+import {
+  ContentHeading,
+  TaxonomyPropType,
+  LinkButton,
+  SiblingBorder,
+} from './shared';
 
 const NO_PARENT_VALUE = 'NO_PARENT_VALUE';
 
@@ -230,62 +235,66 @@ function HierarchicalTermSelector({
   }, [toggleFocus]);
 
   return (
-    <ContentArea>
-      <ContentHeading>{taxonomy.labels.name}</ContentHeading>
-      <HierarchicalInput
-        label={taxonomy.labels.search_items}
-        options={categories}
-        onChange={handleClickCategory}
-        noOptionsText={taxonomy.labels?.not_found}
-      />
-      {canCreateTerms ? (
-        <>
-          {!showAddNewCategory && (
-            <LinkButton
-              ref={toggleRef}
-              aria-expanded={false}
-              onClick={handleToggleNewCategory}
-            >
-              {taxonomy.labels.add_new_item}
-            </LinkButton>
-          )}
-          {showAddNewCategory ? (
-            <AddNewCategoryForm ref={formRef} onSubmit={handleSubmit}>
-              <Input
-                autoFocus
-                name={taxonomy.labels.new_item_name}
-                label={taxonomy.labels.new_item_name}
-                value={newCategoryName}
-                onChange={handleChangeNewCategoryName}
-                hasFocus={hasFocus}
-              />
-              <Label htmlFor={dropdownId}>{taxonomy.labels.parent_item}</Label>
-              <DropDown
-                id={dropdownId}
-                ariaLabel={taxonomy.labels.parent_item}
-                options={dropdownCategories}
-                selectedValue={selectedParent}
-                onMenuItemClick={handleParentSelect}
-              />
-              <ButtonContainer>
-                <AddNewCategoryButton
-                  disabled={!newCategoryName.length}
-                  type="submit"
-                >
-                  {taxonomy.labels.add_new_item}
-                </AddNewCategoryButton>
-                <AddNewCategoryButton
-                  aria-expanded
-                  onClick={handleToggleNewCategory}
-                >
-                  {__('Cancel', 'web-stories')}
-                </AddNewCategoryButton>
-              </ButtonContainer>
-            </AddNewCategoryForm>
-          ) : null}
-        </>
-      ) : null}
-    </ContentArea>
+    <SiblingBorder>
+      <ContentArea>
+        <ContentHeading>{taxonomy.labels.name}</ContentHeading>
+        <HierarchicalInput
+          label={taxonomy.labels.search_items}
+          options={categories}
+          onChange={handleClickCategory}
+          noOptionsText={taxonomy.labels?.not_found}
+        />
+        {canCreateTerms ? (
+          <>
+            {!showAddNewCategory && (
+              <LinkButton
+                ref={toggleRef}
+                aria-expanded={false}
+                onClick={handleToggleNewCategory}
+              >
+                {taxonomy.labels.add_new_item}
+              </LinkButton>
+            )}
+            {showAddNewCategory ? (
+              <AddNewCategoryForm ref={formRef} onSubmit={handleSubmit}>
+                <Input
+                  autoFocus
+                  name={taxonomy.labels.new_item_name}
+                  label={taxonomy.labels.new_item_name}
+                  value={newCategoryName}
+                  onChange={handleChangeNewCategoryName}
+                  hasFocus={hasFocus}
+                />
+                <Label htmlFor={dropdownId}>
+                  {taxonomy.labels.parent_item}
+                </Label>
+                <DropDown
+                  id={dropdownId}
+                  ariaLabel={taxonomy.labels.parent_item}
+                  options={dropdownCategories}
+                  selectedValue={selectedParent}
+                  onMenuItemClick={handleParentSelect}
+                />
+                <ButtonContainer>
+                  <AddNewCategoryButton
+                    disabled={!newCategoryName.length}
+                    type="submit"
+                  >
+                    {taxonomy.labels.add_new_item}
+                  </AddNewCategoryButton>
+                  <AddNewCategoryButton
+                    aria-expanded
+                    onClick={handleToggleNewCategory}
+                  >
+                    {__('Cancel', 'web-stories')}
+                  </AddNewCategoryButton>
+                </ButtonContainer>
+              </AddNewCategoryForm>
+            ) : null}
+          </>
+        ) : null}
+      </ContentArea>
+    </SiblingBorder>
   );
 }
 

--- a/packages/story-editor/src/components/panels/document/taxonomies/shared.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/shared.js
@@ -57,8 +57,18 @@ export const LinkButton = styled(Button).attrs({
   font-weight: 500;
 `;
 
+export const SiblingBorder = styled.div`
+  padding-left: 16px;
+  padding-right: 16px;
+
+  & + & {
+    border-top: 1px solid ${({ theme }) => theme.colors.divider.tertiary};
+    padding-top: 16px;
+  }
+`;
+
 export const WordCloud = {
-  Heading: styled(ContentHeading)`
+  Heading: styled(ContentHeading).attrs({ as: 'h4' })`
     margin-bottom: 4px;
   `,
   Wrapper: styled.div`

--- a/packages/story-editor/src/components/panels/document/taxonomies/shared.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/shared.js
@@ -64,6 +64,7 @@ export const SiblingBorder = styled.div`
   & + & {
     border-top: 1px solid ${({ theme }) => theme.colors.divider.tertiary};
     padding-top: 16px;
+    padding-bottom: 8px;
   }
 `;
 

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -28,6 +28,7 @@ import { SimplePanel } from '../../panel';
 import { useStory } from '../../../../app';
 import HierarchicalTermSelector from './HierarchicalTermSelector';
 import FlatTermSelector from './FlatTermSelector';
+import { SiblingBorder } from './shared';
 
 const StyledSimplePanel = styled(SimplePanel)`
   padding-left: 0;
@@ -72,18 +73,20 @@ function TaxonomiesPanel(props) {
             capabilities[`create-${taxonomy?.slug}`]
         );
 
-        return taxonomy.hierarchical ? (
-          <HierarchicalTermSelector
-            taxonomy={taxonomy}
-            key={taxonomy.slug}
-            canCreateTerms={canCreateTerms}
-          />
-        ) : (
-          <FlatTermSelector
-            taxonomy={taxonomy}
-            key={taxonomy.slug}
-            canCreateTerms={canCreateTerms}
-          />
+        return (
+          <SiblingBorder key={taxonomy.slug}>
+            {taxonomy.hierarchical ? (
+              <HierarchicalTermSelector
+                taxonomy={taxonomy}
+                canCreateTerms={canCreateTerms}
+              />
+            ) : (
+              <FlatTermSelector
+                taxonomy={taxonomy}
+                canCreateTerms={canCreateTerms}
+              />
+            )}
+          </SiblingBorder>
         );
       })}
     </StyledSimplePanel>

--- a/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/taxonomies.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import { __ } from '@web-stories-wp/i18n';
+import styled from 'styled-components';
 
 /**
  * Internal dependencies
@@ -27,6 +28,11 @@ import { SimplePanel } from '../../panel';
 import { useStory } from '../../../../app';
 import HierarchicalTermSelector from './HierarchicalTermSelector';
 import FlatTermSelector from './FlatTermSelector';
+
+const StyledSimplePanel = styled(SimplePanel)`
+  padding-left: 0;
+  padding-right: 0;
+`;
 
 function TaxonomiesPanel(props) {
   const { capabilities } = useStory(({ state: { capabilities } }) => ({
@@ -55,7 +61,7 @@ function TaxonomiesPanel(props) {
   }
 
   return (
-    <SimplePanel
+    <StyledSimplePanel
       name="taxonomies"
       title={__('Categories and Tags', 'web-stories')}
       {...props}
@@ -80,7 +86,7 @@ function TaxonomiesPanel(props) {
           />
         );
       })}
-    </SimplePanel>
+    </StyledSimplePanel>
   );
 }
 

--- a/packages/story-editor/src/components/panels/panel/simplePanel.js
+++ b/packages/story-editor/src/components/panels/panel/simplePanel.js
@@ -26,7 +26,7 @@ import Panel from './panel';
 import PanelTitle from './shared/title';
 import PanelContent from './shared/content';
 
-function SimplePanel({ children, name, ariaLabel, title, ...rest }) {
+function SimplePanel({ children, name, ariaLabel, title, className, ...rest }) {
   return (
     <Panel name={name} {...rest}>
       <PanelTitle
@@ -34,7 +34,7 @@ function SimplePanel({ children, name, ariaLabel, title, ...rest }) {
       >
         {title}
       </PanelTitle>
-      <PanelContent>{children}</PanelContent>
+      <PanelContent className={className}>{children}</PanelContent>
     </Panel>
   );
 }
@@ -44,6 +44,7 @@ SimplePanel.propTypes = {
   name: PropTypes.string.isRequired,
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   ariaLabel: PropTypes.string,
+  className: PropTypes.string,
 };
 
 export default SimplePanel;


### PR DESCRIPTION
## Context
Found in most recent bug bash
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary
Adds a border between `Categories` & `Tags` section
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices
Didn't use the `taxonomy.labels.search_item` for the search placeholder cus it would be too repetitive and specific for a placeholder. instead just used the agnostic action name `search`.
<!-- Please describe your changes. -->

## To-do
NA
<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
Adds a border between `Categories` & `Tags` section and a placeholder for the Category search input
<img width="310" alt="Screen Shot 2021-10-06 at 2 14 55 PM" src="https://user-images.githubusercontent.com/35983235/136268270-f2dc57f1-355b-4fe7-8d30-7629b3745989.png">

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions
<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Go to Editor -> Document Tab -> Categories & Tags Panel
2. See that there is now a border between `Category` and `Tag` inputs
3. See that the Categories search input has a placeholder of `search`


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9272
Fixes #9271 
Fixes #9300
