### PR TITLE
E2E Tests: Reduce screenshot flakiness

### DIFF
--- a/packages/e2e-tests/src/specs/dashboard/templates/useTemplate.js
+++ b/packages/e2e-tests/src/specs/dashboard/templates/useTemplate.js
@@ -65,6 +65,14 @@ describe('Template', () => {
     await expect(page).toMatchElement('input[placeholder="Add title"]');
     await expect(page).toMatchElement('[data-element-id]');
 
+    // Wait for skeleton thumbnails in the carousel to render before taking a screenshot.
+    await page.waitForFunction(
+      () =>
+        !document.querySelector(
+          'li[data-testid^="carousel-page-preview-skeleton"]'
+        ),
+      { timeout: 5000 } // requestIdleCallback in the carousel kicks in after 5s the latest.
+    );
     await percySnapshot(page, 'Story From Template');
 
     // Select a text layer so 'Saved Colors' panel is present

--- a/packages/e2e-tests/src/specs/dashboard/templates/useTemplate.js
+++ b/packages/e2e-tests/src/specs/dashboard/templates/useTemplate.js
@@ -40,8 +40,6 @@ describe('Template', () => {
       '[data-testid="template-grid-item-1"]'
     );
 
-    await percySnapshot(page, 'Explore Templates');
-
     await expect(firstTemplate).toClick('a', { text: 'See details' });
     // Get count of template colors to compare to 'saved colors' in the editor.
     const templateDetailsColors = await page.evaluate(() => {

--- a/packages/e2e-tests/src/specs/editor/editor.js
+++ b/packages/e2e-tests/src/specs/editor/editor.js
@@ -79,8 +79,6 @@ describe('Story Editor', () => {
     await previewPage.waitForSelector('amp-story-player');
     await expect(previewPage).toMatchElement('amp-story-player');
 
-    await percySnapshot(previewPage, 'Preview with development mode');
-
     await editorPage.bringToFront();
     await previewPage.close();
   });

--- a/packages/e2e-tests/src/specs/editor/taxonomy.js
+++ b/packages/e2e-tests/src/specs/editor/taxonomy.js
@@ -25,7 +25,6 @@ import {
   insertStoryTitle,
   withPlugin,
 } from '@web-stories-wp/e2e-test-utils';
-import percySnapshot from '@percy/puppeteer';
 
 async function goToAndExpandTaxonomyPanel() {
   await expect(page).toClick('li[role="tab"]', { text: 'Document' });
@@ -151,8 +150,6 @@ describe('taxonomy', () => {
       await expect(page).toMatchElement(
         'input[name="hierarchical_term_jazz"][checked]'
       );
-
-      await percySnapshot(page, 'Taxonomies - Categories - Admin');
     });
 
     it('should be able to add new tags and existing tags', async () => {
@@ -208,8 +205,6 @@ describe('taxonomy', () => {
       await expect(tokens2).toStrictEqual(
         expect.arrayContaining(['noir', 'action', 'adventure'])
       );
-
-      await percySnapshot(page, 'Taxonomies - Tags - Admin');
     });
   });
 
@@ -245,8 +240,6 @@ describe('taxonomy', () => {
       await expect(page).toMatchElement(
         'input[name="hierarchical_term_rock"][checked]'
       );
-
-      await percySnapshot(page, 'Taxonomies - Categories - Contributor');
     });
 
     it('should be able to add new tags and existing tags', async () => {
@@ -305,8 +298,6 @@ describe('taxonomy', () => {
       await expect(tokens2).toStrictEqual(
         expect.arrayContaining(['rom-com', 'creature feature', 'adventure'])
       );
-
-      await percySnapshot(page, 'Taxonomies - Tags - Contributor');
     });
   });
 

--- a/packages/e2e-tests/src/specs/wordpress/getStartedStory.js
+++ b/packages/e2e-tests/src/specs/wordpress/getStartedStory.js
@@ -36,6 +36,14 @@ describe('Get Started Story', () => {
       await page.waitForSelector('[data-testid="mediaElement-image"]');
       await page.waitForSelector('[data-testid="frameElement"]');
 
+      // Wait for skeleton thumbnails in the carousel to render before taking a screenshot.
+      await page.waitForFunction(
+        () =>
+          !document.querySelector(
+            'li[data-testid^="carousel-page-preview-skeleton"]'
+          ),
+        { timeout: 5000 } // requestIdleCallback in the carousel kicks in after 5s the latest.
+      );
       await percySnapshot(page, 'Get Started Story');
     });
   });
@@ -49,6 +57,14 @@ describe('Get Started Story', () => {
         'post_type=web-story&web-stories-demo=1'
       );
 
+      // Wait for skeleton thumbnails in the carousel to render before taking a screenshot.
+      await page.waitForFunction(
+        () =>
+          !document.querySelector(
+            'li[data-testid^="carousel-page-preview-skeleton"]'
+          ),
+        { timeout: 5000 } // requestIdleCallback in the carousel kicks in after 5s the latest.
+      );
       await percySnapshot(page, 'Get Started Story (Author)');
 
       await expect(page).toMatchElement('input[placeholder="Add title"]');

--- a/packages/story-editor/src/components/carousel/carouselPage.js
+++ b/packages/story-editor/src/components/carousel/carouselPage.js
@@ -117,7 +117,10 @@ function CarouselPage({ pageId, index }) {
   }
 
   return (
-    <ItemContainer ref={(el) => setPageRef(page, el)}>
+    <ItemContainer
+      ref={(el) => setPageRef(page, el)}
+      data-testid={`carousel-page-preview-${pageId}`}
+    >
       {index === 0 && (
         <PageSeparator
           position={0}

--- a/packages/story-editor/src/components/carousel/skeletonPage.js
+++ b/packages/story-editor/src/components/carousel/skeletonPage.js
@@ -73,6 +73,7 @@ function SkeletonPage({ pageId, index }) {
         marginRight: `${pageThumbMargin}px`,
         ...generatePatternStyles(bgColor),
       }}
+      data-testid={`carousel-page-preview-skeleton-${pageId}`}
     />
   );
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

There are lots of Percy screenshots constantly changing due to flakiness, even though there were no changes to those parts. That makes them unreliable.

## Summary

<!-- A brief description of what this PR does. -->

This PR removes some unnecessary screenshots and also tries to reduce flakiness by waiting a tad longer in some cases.

## Relevant Technical Choices

<!-- Please describe your changes. -->

--

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

Testing

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

None

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Verify Percy snapshots


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8793
