### PR TITLE
Page Attachment: Fix `cta-image` AMP validation error

### DIFF
--- a/includes/AMP/Integration/AMP_Story_Sanitizer.php
+++ b/includes/AMP/Integration/AMP_Story_Sanitizer.php
@@ -58,5 +58,6 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->add_video_cache( $this->dom, $this->args['video_cache'] );
 		$this->remove_blob_urls( $this->dom );
 		$this->sanitize_srcset( $this->dom );
+		$this->sanitize_amp_story_page_outlink( $this->dom );
 	}
 }

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -56,5 +56,6 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->add_video_cache( $this->dom, $this->args['video_cache'] );
 		$this->remove_blob_urls( $this->dom );
 		$this->sanitize_srcset( $this->dom );
+		$this->sanitize_amp_story_page_outlink( $this->dom );
 	}
 }

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -98,6 +98,31 @@ trait Sanitization_Utils {
 	}
 
 	/**
+	 * Sanitizes <amp-story-page-outlink> elements to ensure they're always valid.
+	 *
+	 * Removes empty `cta-image` attributes.
+	 *
+	 * @since 1.13.0
+	 *
+	 * @param Document|AMP_Document $document Document instance.
+	 * @return void
+	 */
+	private function sanitize_amp_story_page_outlink( &$document ) {
+		$outlink_elements = $document->getElementsByTagName( 'amp-story-page-outlink' );
+
+		/**
+		 * The <amp-story-page-outlink> element
+		 *
+		 * @var DOMElement $element The <amp-story-page-outlink> element
+		 */
+		foreach ( $outlink_elements as $element ) {
+			if ( ! $element->getAttribute( 'cta-image' ) ) {
+				$element->removeAttribute( 'cta-image' );
+			}
+		}
+	}
+
+	/**
 	 * Replaces the placeholder of publisher logo in the content.
 	 *
 	 * @since 1.1.0

--- a/packages/story-editor/src/output/page.js
+++ b/packages/story-editor/src/output/page.js
@@ -135,7 +135,7 @@ function OutputPage({
       {hasPageAttachment && (
         <amp-story-page-outlink
           layout="nodisplay"
-          cta-image={page.pageAttachment.icon}
+          cta-image={page.pageAttachment.icon || undefined}
           theme={page.pageAttachment.theme}
         >
           <a href={page.pageAttachment.url}>

--- a/packages/story-editor/src/output/test/page.js
+++ b/packages/story-editor/src/output/test/page.js
@@ -19,7 +19,6 @@
  */
 import { renderToStaticMarkup } from '@web-stories-wp/react';
 import { render } from '@testing-library/react';
-jest.mock('flagged');
 import { useFeature } from 'flagged';
 import { PAGE_WIDTH, PAGE_HEIGHT } from '@web-stories-wp/units';
 
@@ -29,6 +28,8 @@ import { PAGE_WIDTH, PAGE_HEIGHT } from '@web-stories-wp/units';
 import PageOutput from '../page';
 import { queryByAutoAdvanceAfter, queryById } from '../../testUtils';
 import { MaskTypes } from '../../masks/constants';
+
+jest.mock('flagged');
 
 /* eslint-disable testing-library/no-node-access, testing-library/no-container */
 
@@ -576,6 +577,31 @@ describe('Page output', () => {
       const { container } = render(<PageOutput {...props} />);
       const pageOutlink = container.querySelector('amp-story-page-outlink');
       await expect(pageOutlink).not.toBeInTheDocument();
+    });
+
+    it('should not output cta-image if empty', async () => {
+      const props = {
+        id: '123',
+        backgroundColor: { color: { r: 255, g: 255, b: 255 } },
+        page: {
+          id: '123',
+          elements: [],
+          pageAttachment: {
+            url: 'https://example.test',
+            ctaText: 'Click me!',
+            theme: 'dark',
+            icon: '',
+          },
+        },
+        autoAdvance: false,
+        defaultPageDuration: 7,
+      };
+
+      const { container } = render(<PageOutput {...props} />);
+      const pageOutlink = container.querySelector('amp-story-page-outlink');
+      await expect(pageOutlink).toHaveTextContent('Click me!');
+      await expect(pageOutlink).not.toHaveAttribute('cta-image');
+      await expect(pageOutlink).toBeInTheDocument();
     });
 
     it('should not output a link in page attachment area', () => {

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -385,4 +385,22 @@ class Story_Sanitizer extends TestCase {
 
 		$this->assertStringContainsString( 'srcset="https://example.com/image.jpg 1000w, https://example.com/image-768x1024.jpg 768w, https://example.com/image-225x300.jpg 225w, https://example.com/image-150x200.jpg 150w"', $actual );
 	}
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::sanitize_amp_story_page_outlink
+	 */
+	public function test_sanitize_amp_story_page_outlink() {
+		$source = '<html><head></head><body><amp-story-page-outlink layout="nodisplay" cta-image=""><a href="https://www.bonappeteach.com/smoked-apple-cider/" target="_blank" rel="noreferrer">Get The Recipe!</a></amp-story-page-outlink></body></html>';
+
+		$args = [
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertStringContainsString( '<amp-story-page-outlink layout="nodisplay">', $actual );
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

We got a user report about page attachments causing AMP validation errors if `cta-image` is omitted/removed, because then we set its value to an empty string, and `cta-image=""` is invalid.

## Summary

<!-- A brief description of what this PR does. -->

This PR removes any `cta-image` attributes with empty values at the sanitization stage.

In addition, it ensures that empty `cta-image` values never get into the client-side generated output in the first place.

## Relevant Technical Choices

<!-- Please describe your changes. -->

N/A

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

No visual changes

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create new page
2. Add page attachment
3. Remove link icon (if set)
4. Preview story
5. Don't get AMP validation error related to `cta-image`


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9307
