### PR TITLE
Update link icon callback to expect resource

### DIFF
--- a/packages/story-editor/src/components/panels/design/link/link.js
+++ b/packages/story-editor/src/components/panels/design/link/link.js
@@ -170,8 +170,13 @@ function LinkPanel({ selectedElements, pushUpdateForObject }) {
   );
 
   const handleChangeIcon = useCallback(
-    (image) => {
-      handleChange({ icon: image?.sizes?.full?.url || image?.url }, true);
+    /**
+     * Handle link icon change.
+     *
+     * @param {import('@web-stories-wp/media').Resource} resource The new image.
+     */
+    (resource) => {
+      handleChange({ icon: resource.src }, true);
     },
     [handleChange]
   );

--- a/packages/story-editor/src/components/panels/design/pageAttachment/pageAttachment.js
+++ b/packages/story-editor/src/components/panels/design/pageAttachment/pageAttachment.js
@@ -175,11 +175,13 @@ function PageAttachmentPanel() {
   );
 
   const handleChangeIcon = useCallback(
-    (image) => {
-      updatePageAttachment(
-        { icon: image?.sizes?.full?.url || image?.url },
-        true
-      );
+    /**
+     * Handle page attachment icon change.
+     *
+     * @param {import('@web-stories-wp/media').Resource} resource The new image.
+     */
+    (resource) => {
+      updatePageAttachment({ icon: resource.src }, true);
     },
     [updatePageAttachment]
   );

--- a/packages/story-editor/src/components/panels/design/videoAccessibility/videoAccessibility.js
+++ b/packages/story-editor/src/components/panels/design/videoAccessibility/videoAccessibility.js
@@ -76,13 +76,13 @@ function VideoAccessibilityPanel({ selectedElements, pushUpdate }) {
     /**
      * Handle video poster change.
      *
-     * @param {import('@web-stories-wp/media').Resource} newPoster The new image.
+     * @param {import('@web-stories-wp/media').Resource} [newPoster] The new image. Or null if reset.
      */
     (newPoster) => {
-      if (newPoster.src === rawPoster) {
+      if (newPoster?.src === rawPoster) {
         return;
       }
-      pushUpdate({ poster: newPoster.src }, true);
+      pushUpdate({ poster: newPoster?.src }, true);
     },
     [pushUpdate, rawPoster]
   );

--- a/packages/story-editor/src/components/panels/design/videoAccessibility/videoAccessibility.js
+++ b/packages/story-editor/src/components/panels/design/videoAccessibility/videoAccessibility.js
@@ -73,12 +73,16 @@ function VideoAccessibilityPanel({ selectedElements, pushUpdate }) {
   } = useConfig();
 
   const handleChangePoster = useCallback(
-    (image) => {
-      const newPoster = image?.sizes?.full?.source_url || image?.src;
-      if (newPoster === rawPoster) {
+    /**
+     * Handle video poster change.
+     *
+     * @param {import('@web-stories-wp/media').Resource} newPoster The new image.
+     */
+    (newPoster) => {
+      if (newPoster.src === rawPoster) {
         return;
       }
-      pushUpdate({ poster: newPoster }, true);
+      pushUpdate({ poster: newPoster.src }, true);
     },
     [pushUpdate, rawPoster]
   );

--- a/packages/story-editor/src/components/panels/document/publish/publish.js
+++ b/packages/story-editor/src/components/panels/document/publish/publish.js
@@ -159,17 +159,24 @@ function PublishPanel() {
   );
 
   const handleChangePoster = useCallback(
-    (image) =>
-      updateStory({
+    /**
+     * Handle story poster change.
+     *
+     * @param {import('@web-stories-wp/media').Resource} newPoster The new image.
+     * @return {void}
+     */
+    (newPoster) => {
+      return updateStory({
         properties: {
           featuredMedia: {
-            id: image.id,
-            height: image.sizes?.full?.height || image.height,
-            url: image.sizes?.full?.source_url || image.src,
-            width: image.sizes?.full?.width || image.width,
+            id: newPoster.id,
+            url: newPoster.src,
+            height: newPoster.height,
+            width: newPoster.width,
           },
         },
-      }),
+      });
+    },
     [updateStory]
   );
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

We received a user report that changing the page attachment icon doesn't work.

## Summary

<!-- A brief description of what this PR does. -->

This PR updates all the callbacks for media inputs to expect resource objects instead of whatever they did before. This makes things more clear and functional again.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Added some JSDoc everywhere for clarification.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

--

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

**Page Attachment**

1. Create a new page
2. Add page attachment
3. Add link icon
4. Verify that the icon has been added

**Link**

1. Add a new element to the page
2. Add a link to the element
3. Verify that the icon has been added

**Video Poster**

1. Add a new video to the page
2. Edit video poster in the design panel and select a new one
3. Verify that the poster has been changed

**Story Poster**

1. Change the story poster image in the document panel and select a new one
2. Verify that the poster has been changed


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9309
