### PR TITLE
Taxonomy: Rename default parent category option in dropdown

### DIFF
--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -123,10 +123,10 @@ function HierarchicalTermSelector({
       [
         {
           value: NO_PARENT_VALUE,
-          label: `-- ${taxonomy.labels?.parent_item} --`,
+          label: __('None', 'web-stories'),
         },
       ].concat(categories),
-    [categories, taxonomy]
+    [categories]
   );
 
   const [showAddNewCategory, setShowAddNewCategory] = useState(false);


### PR DESCRIPTION

## Context

Feedback from bugbash, the default (no parent) option in the new category dropdown is inconsistent with the other Story category view. 

## Summary

Changes the default label of parent category dropdown used for adding a new category.

| Old | New | Other Categories view used as reference | 
| --- | --- | --- | 
| ![Screen Shot 2021-10-06 at 3 06 20 PM](https://user-images.githubusercontent.com/10720454/136290150-43e4e348-e9be-4d77-ba36-328a7181150b.png) | ![Screen Shot 2021-10-06 at 3 00 19 PM](https://user-images.githubusercontent.com/10720454/136290058-e7f54596-f45c-493b-9c08-da436842bcb9.png) | ![Screen Shot 2021-10-06 at 3 01 12 PM](https://user-images.githubusercontent.com/10720454/136290077-c47fc7ba-b9e7-4244-a090-d4e0fb8e1710.png) |

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9278 
