### PR TITLE
Design System: Normalize Box-Shadow: None

### DIFF
--- a/packages/design-system/src/components/input/index.js
+++ b/packages/design-system/src/components/input/index.js
@@ -130,7 +130,9 @@ export const BaseInput = styled.input(
         color: ${theme.colors.fg.disable};
       }
     }
-
+    :focus {
+      box-shadow: none;
+    }
     :active:enabled {
       color: ${theme.colors.fg.primary};
     }

--- a/packages/design-system/src/components/input/index.js
+++ b/packages/design-system/src/components/input/index.js
@@ -106,6 +106,7 @@ export const BaseInput = styled.input(
     background-color: inherit;
     border: none;
     outline: none;
+    box-shadow: none;
     color: ${theme.colors.fg.primary};
 
     ${themeHelpers.expandPresetStyles({


### PR DESCRIPTION
## Context

During bugbash, Morten was seeing a weird red box-shadow around the taxonomy > categories search input when in focus. 

## Summary

Hopefully fixing the edge case Morten's seeing. 

## Relevant Technical Choices

Setting box-shadow to none in the DS `Input` in general but also on `:focus` so it's not an issue moving forward anywhere else.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

Focus the 'search' input for Categories in the document panel, should not see an ugly red box-shadow (looks like a border)

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9276 
