### PR TITLE
Video: Allow re-trimming of already trimmed video

### DIFF
--- a/packages/media/src/getMsFromHMS.js
+++ b/packages/media/src/getMsFromHMS.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Converts time in H:M:S format to milliseconds.
+ *
+ * @param {string} time Time in HH:MM:SS or H:M:S format.
+ * @return {number} Milliseconds.
+ */
+function getMsFromHMS(time) {
+  if (!time) {
+    return 0;
+  }
+  const parts = time.split(':');
+  if (parts.length !== 3) {
+    return 0;
+  }
+  const seconds =
+    parseFloat(parts[2]) + parseInt(parts[1]) * 60 + parseInt(parts[0]) * 3600;
+  return Math.round(1000 * seconds);
+}
+
+export default getMsFromHMS;

--- a/packages/media/src/index.js
+++ b/packages/media/src/index.js
@@ -30,6 +30,7 @@ export { default as getFileNameWithExt } from './getFileNameWithExt';
 export { default as getExtensionFromMimeType } from './getExtensionFromMimeType';
 export { default as getFirstFrameOfVideo } from './getFirstFrameOfVideo';
 export { default as getImageDimensions } from './getImageDimensions';
+export { default as getMsFromHMS } from './getMsFromHMS';
 export { default as getVideoDimensions } from './getVideoDimensions';
 export { default as getVideoLength } from './getVideoLength';
 export { default as getVideoLengthDisplay } from './getVideoLengthDisplay';

--- a/packages/media/src/test/getMsFromHMS.js
+++ b/packages/media/src/test/getMsFromHMS.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Internal dependencies
+ */
+import getMsFromHMS from '../getMsFromHMS';
+
+describe('getMsFromHMS', () => {
+  it('should correctly format values resulting in 0', () => {
+    expect(getMsFromHMS('00:00:00')).toBe(0);
+    expect(getMsFromHMS(null)).toBe(0);
+    expect(getMsFromHMS('foo')).toBe(0);
+  });
+
+  it('should return correct results', () => {
+    expect(getMsFromHMS('00:00:01')).toBe(1000);
+    expect(getMsFromHMS('00:01:00')).toBe(60000);
+    expect(getMsFromHMS('00:00:10.5')).toBe(10500);
+  });
+});

--- a/packages/story-editor/src/app/api/apiProvider.js
+++ b/packages/story-editor/src/app/api/apiProvider.js
@@ -53,6 +53,7 @@ function APIProvider({ children }) {
     saveStoryById,
     autoSaveById,
     getMedia,
+    getMediaById,
     uploadMedia,
     updateMedia,
     deleteMedia,
@@ -117,6 +118,11 @@ function APIProvider({ children }) {
     ({ mediaType, searchTerm, pagingNum, cacheBust }) =>
       getMedia({ mediaType, searchTerm, pagingNum, cacheBust }, media),
     [media, getMedia]
+  );
+
+  actions.getMediaById = useCallback(
+    (mediaId) => getMediaById(mediaId, media),
+    [getMediaById, media]
   );
 
   actions.uploadMedia = useCallback(

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -59,17 +59,11 @@ function useProcessMedia({
   );
 
   const updateExistingElements = useCallback(
-    ({ oldResource }) => {
-      const { id } = oldResource;
+    ({ oldResource: resource }) => {
+      const { id } = resource;
       updateElementsByResourceId({
         id,
-        properties: () => {
-          return {
-            resource: {
-              ...oldResource,
-            },
-          };
-        },
+        properties: () => ({ resource }),
       });
     },
     [updateElementsByResourceId]
@@ -186,11 +180,11 @@ function useProcessMedia({
    * @param {string} end Time stamp of end time of new video. Example '00:02:00'.
    */
   const trimExistingVideo = useCallback(
-    ({ resource: oldResource, start, end }) => {
+    ({ resource: oldResource, trimSourceId, start, end }) => {
       const { src: url, mimeType, poster } = oldResource;
 
       const trimData = {
-        original: oldResource.id,
+        original: trimSourceId,
         start,
         end,
       };

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -180,11 +180,13 @@ function useProcessMedia({
    * @param {string} end Time stamp of end time of new video. Example '00:02:00'.
    */
   const trimExistingVideo = useCallback(
-    ({ resource: oldResource, trimSourceId, start, end }) => {
-      const { src: url, mimeType, poster } = oldResource;
+    ({ resource: oldResource, canvasResourceId, start, end }) => {
+      const { id, src: url, mimeType, poster } = oldResource;
+
+      const canvasResource = { ...oldResource, id: canvasResourceId };
 
       const trimData = {
-        original: trimSourceId,
+        original: id,
         start,
         end,
       };
@@ -192,7 +194,7 @@ function useProcessMedia({
       const onUploadStart = () => {
         updateExistingElements({
           oldResource: {
-            ...oldResource,
+            ...canvasResource,
             trimData,
             isTrimming: true,
           },
@@ -201,7 +203,10 @@ function useProcessMedia({
 
       const onUploadError = () => {
         updateExistingElements({
-          oldResource: { ...oldResource, isTrimming: false },
+          oldResource: {
+            ...canvasResource,
+            isTrimming: false,
+          },
         });
       };
 
@@ -218,9 +223,9 @@ function useProcessMedia({
       };
 
       const onUploadProgress = ({ resource }) => {
-        const oldResourceWithId = { ...resource, id: oldResource.id };
+        const newResourceWithCanvasId = { ...resource, id: canvasResourceId };
         updateExistingElements({
-          oldResource: oldResourceWithId,
+          oldResource: newResourceWithCanvasId,
         });
       };
 

--- a/packages/story-editor/src/components/videoTrim/provider.js
+++ b/packages/story-editor/src/components/videoTrim/provider.js
@@ -50,7 +50,7 @@ function VideoTrimProvider({ children }) {
   } = useVideoNode(videoData);
 
   const performTrim = useCallback(() => {
-    const { resource } = videoData;
+    const { resource, element } = videoData;
     if (!resource) {
       return;
     }
@@ -58,9 +58,13 @@ function VideoTrimProvider({ children }) {
     trimExistingVideo({
       resource: {
         ...resource,
+        // Preserve the id of the source resource even though we might be trimming from a third resource
+        id: element.resource.id,
         length: lengthInSeconds,
         lengthFormatted: getVideoLengthDisplay(lengthInSeconds),
       },
+      // However, also keep the trim source id available (it might be identical)
+      trimSourceId: resource.id,
       start: formatMsToHMS(startOffset),
       end: formatMsToHMS(endOffset),
     });

--- a/packages/story-editor/src/components/videoTrim/provider.js
+++ b/packages/story-editor/src/components/videoTrim/provider.js
@@ -25,19 +25,17 @@ import { trackEvent } from '@web-stories-wp/tracking';
 /**
  * Internal dependencies
  */
-import { useLocalMedia, useStory } from '../../app';
+import { useLocalMedia } from '../../app';
 import VideoTrimContext from './videoTrimContext';
 import useVideoTrimMode from './useVideoTrimMode';
 import useVideoNode from './useVideoNode';
 
 function VideoTrimProvider({ children }) {
-  const { selectedElements } = useStory(({ state: { selectedElements } }) => ({
-    selectedElements,
-  }));
   const { trimExistingVideo } = useLocalMedia((state) => ({
     trimExistingVideo: state.actions.trimExistingVideo,
   }));
-  const { isTrimMode, hasTrimMode, toggleTrimMode } = useVideoTrimMode();
+  const { isTrimMode, hasTrimMode, toggleTrimMode, videoData } =
+    useVideoTrimMode();
   const {
     hasChanged,
     currentTime,
@@ -48,10 +46,10 @@ function VideoTrimProvider({ children }) {
     setEndOffset,
     setVideoNode,
     resetOffsets,
-  } = useVideoNode();
+  } = useVideoNode(videoData);
 
   const performTrim = useCallback(() => {
-    const { resource } = selectedElements[0];
+    const { resource } = videoData;
     if (!resource) {
       return;
     }
@@ -72,16 +70,11 @@ function VideoTrimProvider({ children }) {
       end_offset: endOffset,
     });
     toggleTrimMode();
-  }, [
-    endOffset,
-    startOffset,
-    trimExistingVideo,
-    selectedElements,
-    toggleTrimMode,
-  ]);
+  }, [endOffset, startOffset, trimExistingVideo, toggleTrimMode, videoData]);
 
   const value = {
     state: {
+      videoData,
       hasChanged,
       isTrimMode,
       hasTrimMode,

--- a/packages/story-editor/src/components/videoTrim/provider.js
+++ b/packages/story-editor/src/components/videoTrim/provider.js
@@ -58,13 +58,12 @@ function VideoTrimProvider({ children }) {
     trimExistingVideo({
       resource: {
         ...resource,
-        // Preserve the id of the source resource even though we might be trimming from a third resource
-        id: element.resource.id,
         length: lengthInSeconds,
         lengthFormatted: getVideoLengthDisplay(lengthInSeconds),
       },
-      // However, also keep the trim source id available (it might be identical)
-      trimSourceId: resource.id,
+      // This is the ID of the resource, that's currently on canvas and needs to be cloned.
+      // It's only different from the above resource, if the canvas resource is a trim of the other.
+      canvasResourceId: element.resource.id,
       start: formatMsToHMS(startOffset),
       end: formatMsToHMS(endOffset),
     });

--- a/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
+++ b/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
@@ -18,13 +18,14 @@
  * External dependencies
  */
 import { useFeature } from 'flagged';
-import { useCallback, useMemo } from '@web-stories-wp/react';
+import { useCallback, useMemo, useState } from '@web-stories-wp/react';
 import { trackEvent } from '@web-stories-wp/tracking';
+import { getMsFromHMS } from '@web-stories-wp/media';
 
 /**
  * Internal dependencies
  */
-import { useCanvas, useStory } from '../../app';
+import { useCanvas, useStory, useAPI } from '../../app';
 import useFFmpeg from '../../app/media/utils/useFFmpeg';
 
 function useVideoTrimMode() {
@@ -44,6 +45,10 @@ function useVideoTrimMode() {
   const { selectedElement } = useStory(({ state: { selectedElements } }) => ({
     selectedElement: selectedElements.length === 1 ? selectedElements[0] : null,
   }));
+  const {
+    actions: { getMediaById },
+  } = useAPI();
+  const [videoData, setVideoData] = useState(null);
 
   const toggleTrimMode = useCallback(() => {
     if (isEditing) {
@@ -54,11 +59,39 @@ function useVideoTrimMode() {
         hasEditMenu: true,
         showOverflow: false,
       });
+
+      if (selectedElement.resource?.trimData?.original) {
+        // First clear any existing data
+        setVideoData(null);
+        // Load correct video resource and set original offsets
+        getMediaById(selectedElement.resource.trimData.original).then(
+          (originalResource) =>
+            setVideoData({
+              element: selectedElement,
+              resource: originalResource,
+              start: getMsFromHMS(selectedElement.resource.trimData.start),
+              end: getMsFromHMS(selectedElement.resource.trimData.end),
+            })
+        );
+      } else {
+        setVideoData({
+          element: selectedElement,
+          resource: selectedElement.resource,
+          start: 0,
+          end: null,
+        });
+      }
     }
     trackEvent('video_trim_mode_toggled', {
       status: isEditing ? 'closed' : 'open',
     });
-  }, [isEditing, clearEditing, setEditingElementWithState, selectedElement]);
+  }, [
+    isEditing,
+    clearEditing,
+    setEditingElementWithState,
+    selectedElement,
+    getMediaById,
+  ]);
 
   const { isTranscodingEnabled } = useFFmpeg();
 
@@ -74,6 +107,7 @@ function useVideoTrimMode() {
     isTrimMode: isEditing && isTrimMode,
     hasTrimMode,
     toggleTrimMode,
+    videoData,
   };
 }
 

--- a/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
+++ b/packages/story-editor/src/components/videoTrim/useVideoTrimMode.js
@@ -60,26 +60,36 @@ function useVideoTrimMode() {
         showOverflow: false,
       });
 
-      if (selectedElement.resource?.trimData?.original) {
+      const { resource } = selectedElement;
+      const { trimData } = resource;
+
+      const defaultVideoData = {
+        element: selectedElement,
+        resource,
+        start: 0,
+        end: null,
+      };
+
+      if (trimData?.original) {
         // First clear any existing data
         setVideoData(null);
-        // Load correct video resource and set original offsets
-        getMediaById(selectedElement.resource.trimData.original).then(
-          (originalResource) =>
-            setVideoData({
+        // Load correct video resource
+        getMediaById(trimData.original)
+          .then(
+            // If exists, use as resource with offsets
+            (originalResource) => ({
               element: selectedElement,
               resource: originalResource,
-              start: getMsFromHMS(selectedElement.resource.trimData.start),
-              end: getMsFromHMS(selectedElement.resource.trimData.end),
-            })
-        );
+              start: getMsFromHMS(trimData.start),
+              end: getMsFromHMS(trimData.end),
+            }),
+            // If load fails, pretend there's no original
+            () => defaultVideoData
+          )
+          // Regardless, set resulting data as video data
+          .then((data) => setVideoData(data));
       } else {
-        setVideoData({
-          element: selectedElement,
-          resource: selectedElement.resource,
-          start: 0,
-          end: null,
-        });
+        setVideoData(defaultVideoData);
       }
     }
     trackEvent('video_trim_mode_toggled', {

--- a/packages/story-editor/src/components/videoTrim/videoTrimmer.js
+++ b/packages/story-editor/src/components/videoTrim/videoTrimmer.js
@@ -54,9 +54,17 @@ function VideoTrimmer() {
     hasChanged,
     performTrim,
     toggleTrimMode,
+    videoData,
   } = useVideoTrim(
     ({
-      state: { currentTime, startOffset, endOffset, maxOffset, hasChanged },
+      state: {
+        currentTime,
+        startOffset,
+        endOffset,
+        maxOffset,
+        hasChanged,
+        videoData,
+      },
       actions: { setStartOffset, setEndOffset, performTrim, toggleTrimMode },
     }) => ({
       currentTime,
@@ -68,6 +76,7 @@ function VideoTrimmer() {
       hasChanged,
       performTrim,
       toggleTrimMode,
+      videoData,
     })
   );
   const { workspaceWidth, pageWidth } = useLayout(
@@ -89,7 +98,7 @@ function VideoTrimmer() {
     }
   }, []);
 
-  if (!pageWidth || !maxOffset) {
+  if (!pageWidth || !maxOffset || !videoData) {
     // We still need a reffed element, or the focus trap will break,
     // so just return an empty element
     return <Menu ref={menu} />;

--- a/packages/story-editor/src/elements/video/trim.js
+++ b/packages/story-editor/src/elements/video/trim.js
@@ -27,6 +27,7 @@ import { getMediaSizePositionProps } from '@web-stories-wp/media';
 import StoryPropTypes from '../../types';
 import MediaDisplay from '../media/display';
 import useVideoTrim from '../../components/videoTrim/useVideoTrim';
+import CircularProgress from '../../components/circularProgress';
 import PlayPauseButton from './playPauseButton';
 import { getBackgroundStyle, videoWithScale } from './util';
 
@@ -43,10 +44,18 @@ const Wrapper = styled.div`
   position: absolute;
 `;
 
+const Spinner = styled.div`
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 function VideoTrim({ box, element }) {
   const { width, height } = box;
-  const { poster, resource, tracks, isBackground, scale, focalX, focalY } =
-    element;
+  const { poster, tracks, isBackground, scale, focalX, focalY } = element;
   const wrapperRef = useRef();
   const videoRef = useRef();
   let style = {};
@@ -56,6 +65,39 @@ function VideoTrim({ box, element }) {
       ...style,
       ...styleProps,
     };
+  }
+
+  const { resource, setVideoNode } = useVideoTrim(
+    ({ state: { videoData }, actions: { setVideoNode } }) => ({
+      setVideoNode,
+      resource: videoData?.resource,
+    })
+  );
+
+  const boxAtOrigin = useMemo(
+    () => ({
+      ...box,
+      x: 0,
+      y: 0,
+    }),
+    [box]
+  );
+  const setRef = useCallback(
+    (node) => {
+      videoRef.current = node;
+      setVideoNode(node);
+    },
+    [setVideoNode]
+  );
+
+  if (!resource) {
+    return (
+      <Wrapper>
+        <Spinner>
+          <CircularProgress />
+        </Spinner>
+      </Wrapper>
+    );
   }
 
   const videoProps = getMediaSizePositionProps(
@@ -68,26 +110,6 @@ function VideoTrim({ box, element }) {
   );
 
   videoProps.crossOrigin = 'anonymous';
-
-  const boxAtOrigin = useMemo(
-    () => ({
-      ...box,
-      x: 0,
-      y: 0,
-    }),
-    [box]
-  );
-
-  const { setVideoNode } = useVideoTrim(({ actions: { setVideoNode } }) => ({
-    setVideoNode,
-  }));
-  const setRef = useCallback(
-    (node) => {
-      videoRef.current = node;
-      setVideoNode(node);
-    },
-    [setVideoNode]
-  );
 
   return (
     <>

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -82,9 +82,7 @@ export function getMediaById(mediaId, media) {
     _fields: MEDIA_FIELDS,
   });
 
-  return apiFetch({ path }).then((attachment) =>
-    getResourceFromAttachment(attachment)
-  );
+  return apiFetch({ path }).then(getResourceFromAttachment);
 }
 
 /**

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -70,6 +70,24 @@ export function getMedia(
 }
 
 /**
+ * Get media by ID.
+ *
+ * @param {number} mediaId Media ID.
+ * @param {Object} media   Media object.
+ * @return {Promise} Media object promise.
+ */
+export function getMediaById(mediaId, media) {
+  const path = addQueryArgs(`${media}${mediaId}/`, {
+    context: 'edit',
+    _fields: MEDIA_FIELDS,
+  });
+
+  return apiFetch({ path }).then((attachment) =>
+    getResourceFromAttachment(attachment)
+  );
+}
+
+/**
  * Upload file to via REST API.
  *
  * @param {File}    file           Media File to Save.


### PR DESCRIPTION
## Context

This implements re-trimming an already trimmed video by abstracting out which video is being trimmed completely from most components.

## To-do

Some things that could be added, but don't have to be:

* [ ] Caching the loaded media and checking if we might even already have it in the media library.
* [ ] Agree what the custom poster should be (should it be taken from the video being re-trimmed or the original video?)

## User-facing changes

Trimming a video, that has already been trimmed, now shows the full original video with the handles placed correctly:
![retrim](https://user-images.githubusercontent.com/637548/136409649-3f590498-ecd0-485a-b414-6df5182f9561.gif)

## Testing Instructions

This PR can be tested by following these steps:

1. Add an original (not trimmed) video to a page
2. Click to enter trim mode and observe, that the handles start at the far end for the trim rail
3. Move both handles in and press to trim the video
4. When trimming is fully completed press to trim the new video again
5. Observe that the trim handles are now placed exactly as before with the same indents made before pressing the trim button
6. Move the trim handles to completely new positions and press trim to re-trim the video
7. Once trimming has completed, observe that this third video is correctly trimmed to the desired interval (optionally by entering trim mode to see the handle positions and play the loop)
8. Insert another copy of the newly trimmed video on the canvas
9. Press to enter trim mode and observe the same trim position is still the case

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

Fixes #8892
