### PR TITLE
Fix test regression for inserting presets

### DIFF
--- a/packages/story-editor/src/components/library/test/text/textPane.js
+++ b/packages/story-editor/src/components/library/test/text/textPane.js
@@ -69,7 +69,7 @@ describe('TextPane', () => {
     }));
   });
 
-  it('should insert text with preset text style on pressing a preset', async () => {
+  it('should insert text with preset text style when clicking Enter', async () => {
     const availableCuratedFonts = fontsListResponse.filter(
       (font) => curatedFontNames.indexOf(font.name) > 0
     );
@@ -121,7 +121,12 @@ describe('TextPane', () => {
     );
 
     act(() => {
-      fireEvent.click(screen.getByRole('button', { name: 'Title 1' }));
+      // Note: onClick handler is in Moveable so we can't test that directly in this component
+      // and have to test using key handlers instead.
+      fireEvent.keyDown(screen.getByRole('button', { name: 'Title 1' }), {
+        key: 'Enter',
+        which: 13,
+      });
     });
 
     await waitFor(() => expect(insertPreset).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
## Context
See failing unit tests in https://github.com/google/web-stories-wp/pull/9295
<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
