### PR TITLE
Taxonomies: Add Live Regions

### DIFF
--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -108,6 +108,7 @@ function Input({
 
   // isInputFocused is used to update the styled state of the input area.
   const [isInputFocused, setIsInputFocused] = useState(false);
+  const [isSuggestionsOpen, setIsSuggestionsOpen] = useState(false);
 
   // inputRef is used to return focus to input after keydown actions to avoid focused state being hijacked.
   const inputRef = useRef();
@@ -120,7 +121,11 @@ function Input({
 
   const suggestionListId = uuidv4();
   const totalSuggestions = suggestedTerms.length;
-  const isSuggestionsOpen = totalSuggestions > 0;
+  // suggestedTerms is returned from a debounced callback,
+  // we want to update isSuggestionsOpen via a useEffect to prevent sluggish closing.
+  useEffect(() => {
+    setIsSuggestionsOpen(totalSuggestions > 0);
+  }, [totalSuggestions]);
 
   // Allow parents to pass onTagsChange callback
   // that updates as tags does.
@@ -192,6 +197,7 @@ function Input({
 
   const handleTagSelectedFromSuggestions = useCallback((e, selectedValue) => {
     e.preventDefault();
+    setIsSuggestionsOpen(false);
     dispatch({ type: ACTIONS.SUBMIT_VALUE, payload: selectedValue });
     inputRef?.current.focus();
   }, []);

--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -108,7 +108,6 @@ function Input({
 
   // isInputFocused is used to update the styled state of the input area.
   const [isInputFocused, setIsInputFocused] = useState(false);
-  const [isSuggestionsOpen, setIsSuggestionsOpen] = useState(false);
 
   // inputRef is used to return focus to input after keydown actions to avoid focused state being hijacked.
   const inputRef = useRef();
@@ -121,9 +120,7 @@ function Input({
 
   const suggestionListId = uuidv4();
   const totalSuggestions = suggestedTerms.length;
-  useEffect(() => {
-    setIsSuggestionsOpen(totalSuggestions > 0);
-  }, [totalSuggestions]);
+  const isSuggestionsOpen = totalSuggestions > 0;
 
   // Allow parents to pass onTagsChange callback
   // that updates as tags does.
@@ -195,7 +192,6 @@ function Input({
 
   const handleTagSelectedFromSuggestions = useCallback((e, selectedValue) => {
     e.preventDefault();
-    setIsSuggestionsOpen(false);
     dispatch({ type: ACTIONS.SUBMIT_VALUE, payload: selectedValue });
     inputRef?.current.focus();
   }, []);
@@ -222,7 +218,6 @@ function Input({
     },
     [handleTagSelectedFromSuggestions, totalSuggestions]
   );
-
   return (
     <Border ref={containerRef} isInputFocused={isInputFocused}>
       <InputWrapper>

--- a/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
@@ -24,8 +24,9 @@ import {
   useState,
   useEffect,
 } from '@web-stories-wp/react';
-import { __ } from '@web-stories-wp/i18n';
+import { __, sprintf, _n } from '@web-stories-wp/i18n';
 import PropTypes from 'prop-types';
+import { useLiveRegion } from '@web-stories-wp/design-system';
 /**
  * Internal dependencies
  */
@@ -65,6 +66,8 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
 
   const { undo } = useHistory(({ actions: { undo } }) => ({ undo }));
   const [searchResults, setSearchResults] = useState([]);
+  const speak = useLiveRegion('assertive');
+  const debouncedSpeak = useDebouncedCallback(speak, 500, { leading: true });
 
   const handleFreeformTermsChange = useCallback(
     (termNames) => {
@@ -116,6 +119,14 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
       per_page: 20,
     });
     setSearchResults(results);
+
+    const count = results.length;
+    const message = sprintf(
+      /* Translators: %d: Number of results. */
+      _n('%d result found.', '%d results found.', 'web-stories', 'web-stories'),
+      count
+    );
+    debouncedSpeak(message);
   }, 300);
 
   const tokens = useMemo(() => {

--- a/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/FlatTermSelector.js
@@ -67,7 +67,6 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
   const { undo } = useHistory(({ actions: { undo } }) => ({ undo }));
   const [searchResults, setSearchResults] = useState([]);
   const speak = useLiveRegion('assertive');
-  const debouncedSpeak = useDebouncedCallback(speak, 500, { leading: true });
 
   const handleFreeformTermsChange = useCallback(
     (termNames) => {
@@ -126,7 +125,7 @@ function FlatTermSelector({ taxonomy, canCreateTerms }) {
       _n('%d result found.', '%d results found.', 'web-stories', 'web-stories'),
       count
     );
-    debouncedSpeak(message);
+    speak(message);
   }, 300);
 
   const tokens = useMemo(() => {

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -17,7 +17,7 @@
 /**
  * External dependencies
  */
-import { __ } from '@web-stories-wp/i18n';
+import { __, sprintf } from '@web-stories-wp/i18n';
 import {
   Button,
   BUTTON_SIZES,
@@ -28,9 +28,11 @@ import {
   Text,
   THEME_CONSTANTS,
   themeHelpers,
+  useLiveRegion,
 } from '@web-stories-wp/design-system';
 import {
   useCallback,
+  useDebouncedCallback,
   useEffect,
   useMemo,
   useRef,
@@ -130,6 +132,8 @@ function HierarchicalTermSelector({
   const [searchText, setSearchText] = useState('');
 
   const handleInputChange = useCallback((value) => setSearchText(value), []);
+  const speak = useLiveRegion('assertive');
+  const debouncedSpeak = useDebouncedCallback(speak, 500, { leading: true });
 
   const resetInputs = useCallback(() => {
     setNewCategoryName('');
@@ -190,9 +194,17 @@ function HierarchicalTermSelector({
       setShowAddNewCategory(false);
       resetInputs();
       setToggleFocus(showAddNewCategory);
+      debouncedSpeak(
+        sprintf(
+          /* Translators: %s: Taxonomy label name. */
+          __('%s added.', 'web-stories'),
+          taxonomy.labels.singular_name
+        )
+      );
     },
     [
       createTerm,
+      debouncedSpeak,
       newCategoryName,
       noParentId,
       resetInputs,
@@ -202,7 +214,6 @@ function HierarchicalTermSelector({
       selectedParentSlug,
     ]
   );
-
   const handleParentSelect = useCallback(
     (_evt, menuItem) => setSelectedParent(menuItem),
     []

--- a/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/HierarchicalTermSelector.js
@@ -32,7 +32,6 @@ import {
 } from '@web-stories-wp/design-system';
 import {
   useCallback,
-  useDebouncedCallback,
   useEffect,
   useMemo,
   useRef,
@@ -133,7 +132,6 @@ function HierarchicalTermSelector({
 
   const handleInputChange = useCallback((value) => setSearchText(value), []);
   const speak = useLiveRegion('assertive');
-  const debouncedSpeak = useDebouncedCallback(speak, 500, { leading: true });
 
   const resetInputs = useCallback(() => {
     setNewCategoryName('');
@@ -191,20 +189,20 @@ function HierarchicalTermSelector({
         slug: selectedParentSlug,
       };
       createTerm(taxonomy, newCategoryName, parentValue, true);
-      setShowAddNewCategory(false);
-      resetInputs();
-      setToggleFocus(showAddNewCategory);
-      debouncedSpeak(
+      speak(
         sprintf(
           /* Translators: %s: Taxonomy label name. */
           __('%s added.', 'web-stories'),
           taxonomy.labels.singular_name
         )
       );
+      setShowAddNewCategory(false);
+      resetInputs();
+      setToggleFocus(showAddNewCategory);
     },
     [
       createTerm,
-      debouncedSpeak,
+      speak,
       newCategoryName,
       noParentId,
       resetInputs,


### PR DESCRIPTION
## Context

Missed some live regions found during bug bash as nice to haves for taxonomy feature. 

## Summary

Adds in a live region to adding new hierarchical (category) terms. 
Adds in a live region to freeform (tag) autocomplete list results. 

## Relevant Technical Choices

List results mimics that which already existed in hierarchical.
Set the debounced callback to `leading: true` so that it would be [triggered immediately the first time around](https://github.com/xnimorz/use-debounce#leadingtrailing-calls). 
Removed a redundant state for autocomplete results showing.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

If a screen reader is in use and the user creates a new category they will hear "Category added." announced by the SR. 
If a screen reader is in use and the user types in a value on the tag input that expands the autocomplete list they will hear the result count of options announced by the SR. 

## Testing Instructions

Turn on a SR (I use this one: https://chrome.google.com/webstore/detail/screen-reader/kgejglhpjiefppelpmljglcjbhoiplfn) and try the above.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9283 
