### PR TITLE
Taxonomy: Tighten up freeform input

### DIFF
--- a/packages/story-editor/src/components/form/tags/input.js
+++ b/packages/story-editor/src/components/form/tags/input.js
@@ -56,14 +56,15 @@ const Border = styled.div`
 const InputWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
-  padding: 3px 6px;
+  padding: 0;
 `;
 
 const TextInput = styled(BaseInput).attrs({ type: 'text' })`
   width: auto;
   flex-grow: 1;
-  height: 38px;
-  margin: 3px 0;
+  height: 32px;
+  margin: 2px 0;
+  padding-left: 4px;
 `;
 
 const SuggestionList = styled(List)`

--- a/packages/story-editor/src/components/form/tags/tag.js
+++ b/packages/story-editor/src/components/form/tags/tag.js
@@ -35,16 +35,16 @@ const Dismiss = styled.button`
   cursor: pointer;
   border-radius: ${({ theme }) => theme.borders.radius.small};
   ${themeHelpers.focusableOutlineCSS};
-  width: 32px;
-  min-width: 32px;
-  height: 32px;
+  width: 22px;
+  min-width: 22px;
+  height: 22px;
   display: flex;
   justify-content: center;
   align-items: center;
 
   svg {
-    height: 16px;
-    width: 16px;
+    height: 20px;
+    width: 20px;
     margin: auto;
   }
 `;
@@ -58,16 +58,17 @@ const Token = styled.span`
   position: relative;
   display: flex;
   align-items: center;
-  padding: 3px 2px;
-  margin: 3px 5px 3px 0;
-  max-width: calc(100% - 16px);
+  padding: 2px;
+  margin: 2px 4px;
+  max-width: calc(100% - 8px);
+  height: 32px;
 `;
 
 const TokenText = styled(Text).attrs({
   forwardedAs: 'span',
   size: THEME_CONSTANTS.TYPOGRAPHY.PRESET_SIZES.SMALL,
 })`
-  padding-left: 11px;
+  padding-left: 10px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/packages/story-editor/src/components/form/tags/tag.js
+++ b/packages/story-editor/src/components/form/tags/tag.js
@@ -59,8 +59,8 @@ const Token = styled.span`
   display: flex;
   align-items: center;
   padding: 2px;
-  margin: 2px 4px;
-  max-width: calc(100% - 8px);
+  margin: 2px;
+  max-width: calc(100% - 4px);
   height: 32px;
 `;
 


### PR DESCRIPTION
## Context

Feedback from bugbash/initial team usage that the freeform (tag) input is a bit fat and could be tightened up to be more inline with the other input heights. 

## Summary

Keeps the initial freeform input at 36px, like our other 1 line inputs. When it needs to wrap it'll grow but until then it stays put - no more little height shift. 

## Relevant Technical Choices

Just height, margin, padding tweaks to get the input and the tags to play nicely together. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

| New | Old | 
| --- | --- | 
| ![Screen Shot 2021-10-07 at 2 30 55 PM](https://user-images.githubusercontent.com/10720454/136465900-f9723c31-aa6c-4b45-b8b3-f837114113df.png) | ![Screen Shot 2021-10-07 at 2 42 32 PM](https://user-images.githubusercontent.com/10720454/136466372-5508fb10-d9c1-429c-8696-8878b766ddec.png) | 
| <img width="308" alt="Screen Shot 2021-10-07 at 2 33 22 PM" src="https://user-images.githubusercontent.com/10720454/136466114-65d90c5f-8556-45cd-8553-8075726bc371.png"> | ![Screen Shot 2021-10-07 at 2 43 08 PM](https://user-images.githubusercontent.com/10720454/136466460-0417d80b-d66e-435b-8f9a-04d68d4c2235.png)| 
| ![Screen Shot 2021-10-07 at 2 31 04 PM](https://user-images.githubusercontent.com/10720454/136465902-b1f9f721-7bf2-4cf3-9a95-81c1fe00c1fc.png) | ![Screen Shot 2021-10-07 at 2 41 49 PM](https://user-images.githubusercontent.com/10720454/136466296-ade8709c-bbd2-41af-9f6f-1e7686a8d7fe.png) | 



## Testing Instructions

Verify there's no height jump after adding the initial tag to the input 


<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9281 
Fixes #9291 
