### PR TITLE
Fix fatal error in `filter_display_post_states()`

### DIFF
--- a/includes/Story_Post_Type.php
+++ b/includes/Story_Post_Type.php
@@ -435,11 +435,11 @@ class Story_Post_Type extends Service_Base implements PluginDeactivationAware, S
 	 * @since 1.12.0
 	 *
 	 * @param string[]|mixed $post_states An array of post display states.
-	 * @param WP_Post        $post        The current post object.
+	 * @param WP_Post|null   $post        The current post object.
 	 * @return string[]|mixed Filtered post display states.
 	 */
-	public function filter_display_post_states( $post_states, WP_Post $post ) {
-		if ( ! is_array( $post_states ) ) {
+	public function filter_display_post_states( $post_states, $post ) {
+		if ( ! is_array( $post_states ) || ! $post ) {
 			return $post_states;
 		}
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

User bug report: https://wordpress.org/support/topic/error-with-las-update/

## Summary

<!-- A brief description of what this PR does. -->

Apparently with some plugins the second param passed to `display_post_states` can sometimes be `null` instead of a `WP_Post`, causing a fatal error. This PR fixes that.

## Relevant Technical Choices

<!-- Please describe your changes. -->

N/A

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
No


### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No


## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
