### PR TITLE
Use `memo` for `ReorderableScroller`

### DIFF
--- a/packages/story-editor/src/components/reorderable/reorderableScroller.js
+++ b/packages/story-editor/src/components/reorderable/reorderableScroller.js
@@ -24,6 +24,7 @@ import {
   useState,
   useCallback,
   useContext,
+  memo,
 } from '@web-stories-wp/react';
 
 /**
@@ -120,4 +121,4 @@ ReorderableScroller.propTypes = {
   size: PropTypes.number.isRequired,
 };
 
-export default ReorderableScroller;
+export default memo(ReorderableScroller);


### PR DESCRIPTION
## Summary
This goal of this PR was to `memo` the components that are direct children of context providers.

Testing showed that Max [was correct](https://github.com/google/web-stories-wp/issues/8587#issuecomment-892727011) and the way we use the providers already comes with the benefit. Adding `memo` to the children of providers used as we mostly do, did not reduce the count of renders.

There was one component (`ReorderableScroller`) where it came out to be beneficial though and as an example, the times of being re-rendered was reduced from 8 to 6 in case of switching between two empty pages.

To clarify: in case of `ReorderableScroller`, the component is used directly inside the provider and not as we usually do.

| Before | After |
|--------|------|
| <img width="910" alt="Screenshot 2021-10-08 at 15 36 38" src="https://user-images.githubusercontent.com/3294597/136559156-17b44bd3-31a8-4852-9bbe-255f3fb6a6c6.png"> | <img width="470" alt="Screenshot 2021-10-08 at 15 36 52" src="https://user-images.githubusercontent.com/3294597/136559204-d9c266b8-9b7a-409f-824f-97801ab334bb.png"> |
<!-- A brief description of what this PR does. -->

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes
N/A
<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add one empty page (so you have 2 empty pages as a result).
2. Start the profiler.
3. Click on the non-selected page (ensure that's the only thing you do, no hovering over other elements etc.)
4. Stop the profiler and keep the window open
5. Do the same on `main` in a separate window
6. Compare the results for `ReorderableScoller`.

### Does this PR have a security-related impact?
No
<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
No
<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
No
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8587 
