### PR TITLE
Fix theme support leak in unit tests

### DIFF
--- a/tests/phpunit/integration/tests/Admin/Customizer.php
+++ b/tests/phpunit/integration/tests/Admin/Customizer.php
@@ -65,6 +65,12 @@ class Customizer extends DependencyInjectedTestCase {
 		$this->instance          = $this->injector->make( \Google\Web_Stories\Admin\Customizer::class );
 	}
 
+	public function tear_down() {
+		remove_theme_support( 'web-stories' );
+
+		parent::tear_down();
+	}
+
 	/**
 	 * Add theme support for web stories.
 	 */

--- a/tests/phpunit/integration/tests/Integrations/Core_Themes_Support.php
+++ b/tests/phpunit/integration/tests/Integrations/Core_Themes_Support.php
@@ -59,10 +59,9 @@ class Core_Themes_Support extends DependencyInjectedTestCase {
 	public function tear_down() {
 		remove_action( 'wp_body_open', [ $this->instance, 'embed_web_stories' ] );
 
-		if ( get_theme_support( 'web-stories' ) ) {
-			remove_theme_support( 'web-stories' );
-		}
+		remove_theme_support( 'web-stories' );
 
+		delete_option( Customizer::STORY_OPTION );
 		update_option( 'stylesheet', $this->stylesheet );
 
 		parent::tear_down();
@@ -92,7 +91,6 @@ class Core_Themes_Support extends DependencyInjectedTestCase {
 
 		$this->assertFalse( has_action( 'wp_body_open', [ $this->instance, 'embed_web_stories' ] ) );
 	}
-
 
 	public function test_get_supported_themes() {
 
@@ -133,6 +131,7 @@ class Core_Themes_Support extends DependencyInjectedTestCase {
 	 */
 	public function test_extend_theme_support_non_core_themes() {
 		update_option( 'stylesheet', '' );
+
 		$this->instance->register();
 
 		$this->assertFalse( get_theme_support( 'web-stories' ) );


### PR DESCRIPTION
`add_theme_support( 'web-stories' )` is done in the `Customizer` tests without proper cleanup, causing this to leak to other tests (and make them fail) when running in random order.

Example test run that was failing: https://github.com/google/web-stories-wp/runs/3840108582

This PR makes the tests more robust.