### PR TITLE
Layers panel: Decrease individual layer height

### DIFF
--- a/packages/story-editor/src/components/panels/design/layer/constants.js
+++ b/packages/story-editor/src/components/panels/design/layer/constants.js
@@ -15,4 +15,4 @@
  */
 
 export const DEFAULT_LAYERS_VISIBLE = 6;
-export const LAYER_HEIGHT = 44;
+export const LAYER_HEIGHT = 35;

--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -20,6 +20,7 @@
 import styled, { css } from 'styled-components';
 import { __ } from '@web-stories-wp/i18n';
 import { Button, BUTTON_TYPES, Icons } from '@web-stories-wp/design-system';
+
 /**
  * Internal dependencies
  */
@@ -68,7 +69,6 @@ const LayerButton = styled(Button).attrs({
 `;
 
 const LayerIconWrapper = styled.div`
-  flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: flex-start;
@@ -86,10 +86,12 @@ const LayerDescription = styled.div`
   color: ${({ theme }) => theme.colors.fg.primary};
 `;
 
-const IconWrapper = styled.div`
+const LockIconWrapper = styled.div`
   position: absolute;
-  right: -2px;
-  width: 32px;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
 
   svg {
     color: ${({ theme }) => theme.colors.fg.secondary};
@@ -129,9 +131,9 @@ function Layer({ layer }) {
           )}
         </LayerContentContainer>
         {isBackground && (
-          <IconWrapper>
-            <Icons.LockClosed />
-          </IconWrapper>
+          <LockIconWrapper>
+            <Icons.LockClosed width={35} height={35} />
+          </LockIconWrapper>
         )}
       </LayerDescription>
     </LayerButton>

--- a/packages/story-editor/src/elements/gif/icon.js
+++ b/packages/story-editor/src/elements/gif/icon.js
@@ -25,7 +25,7 @@ function GifLayerIcon({
     resource: { poster, alt },
   },
 }) {
-  return <VisibleImage src={poster} alt={alt} height="20" />;
+  return <VisibleImage src={poster} alt={alt} height={21} width={21} />;
 }
 
 GifLayerIcon.propTypes = {

--- a/packages/story-editor/src/elements/image/icon.js
+++ b/packages/story-editor/src/elements/image/icon.js
@@ -31,7 +31,7 @@ function ImageLayerIcon({
   },
 }) {
   const src = getSmallestUrlForWidth(0, resource);
-  return <VisibleImage src={src} alt={alt} height="20" />;
+  return <VisibleImage src={src} alt={alt} height={21} width={21} />;
 }
 
 ImageLayerIcon.propTypes = {

--- a/packages/story-editor/src/elements/media/videoImage.js
+++ b/packages/story-editor/src/elements/media/videoImage.js
@@ -22,8 +22,8 @@ import PropTypes from 'prop-types';
 
 const Video = styled.video`
   display: block;
-  height: 28px;
-  width: 28px;
+  height: 21px;
+  width: 21px;
   border-radius: ${({ theme }) => theme.borders.radius.small};
   object-fit: cover;
 `;

--- a/packages/story-editor/src/elements/media/visibleImage.js
+++ b/packages/story-editor/src/elements/media/visibleImage.js
@@ -22,8 +22,8 @@ import PropTypes from 'prop-types';
 
 const Image = styled.img`
   display: block;
-  height: 28px;
-  width: 28px;
+  height: 21px;
+  width: 21px;
   border-radius: ${({ theme }) => theme.borders.radius.small};
   object-fit: cover;
 `;

--- a/packages/story-editor/src/elements/shape/icon.js
+++ b/packages/story-editor/src/elements/shape/icon.js
@@ -33,8 +33,8 @@ const Container = styled.div`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  height: 28px;
-  width: 28px;
+  height: 21px;
+  width: 21px;
   border-radius: ${({ theme }) => theme.borders.radius.small};
   background-color: ${({ theme }) => theme.colors.opacity.black10};
 `;

--- a/packages/story-editor/src/elements/sticker/icon.js
+++ b/packages/story-editor/src/elements/sticker/icon.js
@@ -26,8 +26,8 @@ import StoryPropTypes from '../../types';
 
 const style = {
   display: 'block',
-  height: 20,
-  width: 'auto',
+  height: 21,
+  width: 21,
 };
 
 const Noop = () => null;

--- a/packages/story-editor/src/elements/text/icon.js
+++ b/packages/story-editor/src/elements/text/icon.js
@@ -22,7 +22,7 @@ import { Icons } from '@web-stories-wp/design-system';
 
 const IconContainer = styled.div`
   height: auto;
-  width: 28px;
+  width: 21px;
   overflow: hidden;
   /* icon is bigger than icon container, so we need to center manually. */
   margin-left: -1px;
@@ -31,7 +31,7 @@ const IconContainer = styled.div`
 function TextIcon() {
   return (
     <IconContainer>
-      <Icons.LetterT height="30px" width="30px" />
+      <Icons.LetterT height="21px" width="21px" />
     </IconContainer>
   );
 }

--- a/packages/story-editor/src/elements/text/icon.js
+++ b/packages/story-editor/src/elements/text/icon.js
@@ -21,11 +21,9 @@ import styled from 'styled-components';
 import { Icons } from '@web-stories-wp/design-system';
 
 const IconContainer = styled.div`
-  height: auto;
+  height: 21px;
   width: 21px;
   overflow: hidden;
-  /* icon is bigger than icon container, so we need to center manually. */
-  margin-left: -1px;
 `;
 
 function TextIcon() {

--- a/packages/story-editor/src/elements/text/icon.js
+++ b/packages/story-editor/src/elements/text/icon.js
@@ -29,7 +29,7 @@ const IconContainer = styled.div`
 function TextIcon() {
   return (
     <IconContainer>
-      <Icons.LetterT height="21px" width="21px" />
+      <Icons.LetterT height={21} width={21} />
     </IconContainer>
   );
 }

--- a/packages/story-editor/src/elements/video/icon.js
+++ b/packages/story-editor/src/elements/video/icon.js
@@ -39,10 +39,10 @@ function VideoLayerContent({
   if (!iconImage && showVideoPreviewAsBackup) {
     return <VideoImage src={src} alt={alt} />;
   } else if (!iconImage) {
-    return <Icons.Video width={28} height={28} title={alt} />;
+    return <Icons.Video width={21} height={21} title={alt} />;
   }
 
-  return <VisibleImage src={iconImage} alt={alt} width={28} height={28} />;
+  return <VisibleImage src={iconImage} alt={alt} width={21} height={21} />;
 }
 
 VideoLayerContent.propTypes = {


### PR DESCRIPTION
## Context

Layers Panel cosmetic updates.

## Summary

- Vertical size of each panel reduced from 44px to 35px
- Image squares 21x21px

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes



## Testing Instructions

This PR can be tested by following these steps:

1.  Load editor
2. Play with layers panel. You should observer following:
      - Vertical Layer panel item height will be reduced to 35px from 44px.
      - Icon size will be smaller than before i.e. 21px x 21px

## Reviews

### Does this PR have a security-related impact?

NO

### Does this PR change what data or activity we track or use?

NO

### Does this PR have a legal-related impact?

NO

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue 
- [ ] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary

---

Fixes #9254 

