### PR TITLE
Decoupling: Move WP sub menu handling to `wp-dashboard`

### DIFF
--- a/packages/dashboard/src/app/router/routerProvider.js
+++ b/packages/dashboard/src/app/router/routerProvider.js
@@ -51,31 +51,6 @@ function RouterProvider({ children, ...props }) {
     });
   }, []);
 
-  // Sync up WP navigation bar with our hash location.
-  useEffect(() => {
-    let query = `a[href$="#${currentPath}"]`;
-    // `Dashboard` link in WP doesn't have a hash in the href
-    if (currentPath.length <= 1) {
-      query = 'a[href$="page=stories-dashboard"]';
-    }
-
-    const WPSubmenuItems = document.querySelectorAll(
-      '#menu-posts-web-story ul.wp-submenu li'
-    );
-    WPSubmenuItems?.forEach((el) => {
-      el.classList.remove('current');
-      el.querySelector('a')?.classList.remove('current');
-      el.querySelector('a')?.removeAttribute('aria-current');
-    });
-    WPSubmenuItems?.forEach((el) => {
-      if (el.querySelector(query)) {
-        el.classList.add('current');
-        el.querySelector('a')?.classList.add('current');
-        el.querySelector('a')?.setAttribute('aria-current', 'page');
-      }
-    });
-  }, [currentPath]);
-
   const value = useMemo(
     () => ({
       state: {

--- a/packages/wp-dashboard/src/components/index.js
+++ b/packages/wp-dashboard/src/components/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Internal dependencies
- */
-import Dashboard from './dashboard';
-
-export * from './app';
-export * from './app/router';
-export * from './constants';
-export { GlobalStyle as DashboardGlobalStyle } from './theme';
-export { default as DashboardKeyboardOnlyOutline } from './utils/keyboardOnlyOutline';
-export { default as InterfaceSkeleton } from './components/interfaceSkeleton';
-
-export default Dashboard;
+export { default as Layout } from './layout';

--- a/packages/wp-dashboard/src/components/layout/index.js
+++ b/packages/wp-dashboard/src/components/layout/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * External dependencies
+ */
+import { InterfaceSkeleton } from '@web-stories-wp/dashboard';
 
 /**
  * Internal dependencies
  */
-import Dashboard from './dashboard';
+import { useAdminSubMenu } from '../../effects';
 
-export * from './app';
-export * from './app/router';
-export * from './constants';
-export { GlobalStyle as DashboardGlobalStyle } from './theme';
-export { default as DashboardKeyboardOnlyOutline } from './utils/keyboardOnlyOutline';
-export { default as InterfaceSkeleton } from './components/interfaceSkeleton';
+function Layout() {
+  useAdminSubMenu();
 
-export default Dashboard;
+  return <InterfaceSkeleton />;
+}
+
+export default Layout;

--- a/packages/wp-dashboard/src/effects/index.js
+++ b/packages/wp-dashboard/src/effects/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-/**
- * Internal dependencies
- */
-import Dashboard from './dashboard';
-
-export * from './app';
-export * from './app/router';
-export * from './constants';
-export { GlobalStyle as DashboardGlobalStyle } from './theme';
-export { default as DashboardKeyboardOnlyOutline } from './utils/keyboardOnlyOutline';
-export { default as InterfaceSkeleton } from './components/interfaceSkeleton';
-
-export default Dashboard;
+export { default as useAdminSubMenu } from './useAdminSubMenu';

--- a/packages/wp-dashboard/src/effects/useAdminSubMenu.js
+++ b/packages/wp-dashboard/src/effects/useAdminSubMenu.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * External dependencies
+ */
+import { useRouteHistory } from '@web-stories-wp/dashboard';
+import { useEffect } from '@web-stories-wp/react';
+
+function useAdminSubMenu() {
+  const { currentPath } = useRouteHistory(({ state: { currentPath } }) => ({
+    currentPath,
+  }));
+
+  // Sync up WP navigation bar with our hash location.
+  useEffect(() => {
+    let query = `a[href$="#${currentPath}"]`;
+    // `Dashboard` link in WP doesn't have a hash in the href
+    if (currentPath.length <= 1) {
+      query = 'a[href$="page=stories-dashboard"]';
+    }
+
+    const WPSubmenuItems = document.querySelectorAll(
+      '#menu-posts-web-story ul.wp-submenu li'
+    );
+    WPSubmenuItems?.forEach((el) => {
+      el.classList.remove('current');
+      el.querySelector('a')?.classList.remove('current');
+      el.querySelector('a')?.removeAttribute('aria-current');
+    });
+    WPSubmenuItems?.forEach((el) => {
+      if (el.querySelector(query)) {
+        el.classList.add('current');
+        el.querySelector('a')?.classList.add('current');
+        el.querySelector('a')?.setAttribute('aria-current', 'page');
+      }
+    });
+  }, [currentPath]);
+}
+
+export default useAdminSubMenu;

--- a/packages/wp-dashboard/src/index.js
+++ b/packages/wp-dashboard/src/index.js
@@ -26,7 +26,7 @@ import './style.css'; // This way the general dashboard styles are loaded before
 /**
  * External dependencies
  */
-import Dashboard, { InterfaceSkeleton } from '@web-stories-wp/dashboard';
+import Dashboard from '@web-stories-wp/dashboard';
 import { setAppElement } from '@web-stories-wp/design-system';
 import { StrictMode, render } from '@web-stories-wp/react';
 import { FlagsProvider } from 'flagged';
@@ -37,6 +37,7 @@ import { initializeTracking } from '@web-stories-wp/tracking';
  * Internal dependencies
  */
 import getApiCallbacks from './api/utils/getApiCallbacks';
+import { Layout } from './components';
 
 /**
  * Initializes the Web Stories dashboard screen.
@@ -65,7 +66,7 @@ const initialize = async (id, config, flags) => {
     <FlagsProvider features={flags}>
       <StrictMode>
         <Dashboard config={dashboardConfig}>
-          <InterfaceSkeleton />
+          <Layout />
         </Dashboard>
       </StrictMode>
     </FlagsProvider>,


### PR DESCRIPTION
## Context

"Handle `RouterProvider` component using WordPress menu." task from https://github.com/google/web-stories-wp/issues/2918

## Summary



## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
See #789
-->

Partially addresses https://github.com/google/web-stories-wp/issues/2918
