### PR TITLE
Bugfix:  Stuck Swatch Tooltips in Safari

### DIFF
--- a/packages/design-system/src/components/swatch/stories/index.js
+++ b/packages/design-system/src/components/swatch/stories/index.js
@@ -18,11 +18,13 @@
  * External dependencies
  */
 import styled from 'styled-components';
+import { boolean } from '@storybook/addon-knobs';
 
 /**
  * Internal dependencies
  */
 import { DarkThemeProvider } from '../../../storybookUtils';
+import { Tooltip } from '../../tooltip';
 import { Text } from '../../typography';
 import { Cross, Pipette } from '../../../icons';
 import { Swatch } from '../swatch';
@@ -178,6 +180,25 @@ function _default() {
                   {Icon && <Icon />}
                 </Swatch>
               </Cell>
+            ))}
+          </Row>
+        ))}
+        <hr />
+        {DEMO_COLORS.map(({ label, pattern }) => (
+          <Row key={`${label}_tooltip`}>
+            <Text>{`${label} + tooltips`}</Text>
+            {VARIANTS.map(({ variant, Icon, ...props }) => (
+              <Tooltip title={variant} key={variant}>
+                <Cell>
+                  <Swatch
+                    pattern={pattern}
+                    isDisabled={boolean('tooltip variant disable state', false)}
+                    {...props}
+                  >
+                    {Icon && <Icon />}
+                  </Swatch>
+                </Cell>
+              </Tooltip>
             ))}
           </Row>
         ))}

--- a/packages/design-system/src/components/swatch/swatch.js
+++ b/packages/design-system/src/components/swatch/swatch.js
@@ -61,6 +61,7 @@ const SwatchButton = styled.button`
     css`
       opacity: 0.4;
       cursor: default;
+      /* pointer-events none here fixes an edge case in Safari when swatch is within a tooltip #9188 */
       pointer-events: none;
     `}
   ${({ theme }) => themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
@@ -68,6 +69,7 @@ const SwatchButton = styled.button`
   ::after {
     content: '';
     position: absolute;
+    /* pointer-events none here fixes an edge case in Safari when swatch is within a tooltip #9188 */
     pointer-events: none;
     left: 0;
     top: 0;

--- a/packages/design-system/src/components/swatch/swatch.js
+++ b/packages/design-system/src/components/swatch/swatch.js
@@ -44,7 +44,7 @@ const Transparent = styled.div`
   ${themeHelpers.transparentBg}
 `;
 
-const SwatchButton = styled.button.attrs({ type: 'button' })`
+const SwatchButton = styled.button`
   cursor: pointer;
   background-color: transparent;
   border-color: transparent;
@@ -61,12 +61,14 @@ const SwatchButton = styled.button.attrs({ type: 'button' })`
     css`
       opacity: 0.4;
       cursor: default;
+      pointer-events: none;
     `}
   ${({ theme }) => themeHelpers.focusableOutlineCSS(theme.colors.border.focus)};
 
   ::after {
     content: '';
     position: absolute;
+    pointer-events: none;
     left: 0;
     top: 0;
     width: 100%;
@@ -151,11 +153,7 @@ function Swatch({
       {...props}
     >
       {swatchHasTransparency && <Transparent />}
-      <SwatchItem
-        $pattern={pattern}
-        disabled={isDisabled}
-        displaySplit={displaySplit}
-      >
+      <SwatchItem $pattern={pattern} displaySplit={displaySplit}>
         {displaySplit && (
           <OpaqueColorWrapper isSmall={isSmall}>
             <OpaqueColor isSmall={isSmall} pattern={opaquePattern} />

--- a/packages/story-editor/src/components/panels/design/preset/colorPreset/color.js
+++ b/packages/story-editor/src/components/panels/design/preset/colorPreset/color.js
@@ -19,7 +19,6 @@
  */
 import PropTypes from 'prop-types';
 import { __ } from '@web-stories-wp/i18n';
-import styled from 'styled-components';
 import { hasOpacity, hasGradient } from '@web-stories-wp/patterns';
 import { Swatch, Icons } from '@web-stories-wp/design-system';
 /**
@@ -28,12 +27,6 @@ import { Swatch, Icons } from '@web-stories-wp/design-system';
 import { useStory } from '../../../../../app/story';
 import { areAllType } from '../utils';
 import Tooltip from '../../../../tooltip';
-import { focusStyle } from '../../../shared';
-
-const StyledSwatch = styled(Swatch)`
-  ${focusStyle};
-`;
-
 function Color({ color, i, activeIndex, handleOnClick, isEditMode, isLocal }) {
   const { currentPage, selectedElements } = useStory(
     ({ state: { currentPage, selectedElements } }) => {
@@ -69,7 +62,7 @@ function Color({ color, i, activeIndex, handleOnClick, isEditMode, isLocal }) {
 
   return (
     <Tooltip title={tooltip}>
-      <StyledSwatch
+      <Swatch
         aria-label={isEditMode ? deleteLabel : applyLabel}
         isDisabled={isDisabled}
         tabIndex={activeIndex === i ? 0 : -1}
@@ -77,7 +70,7 @@ function Color({ color, i, activeIndex, handleOnClick, isEditMode, isLocal }) {
         pattern={color}
       >
         {isEditMode && <Icons.Cross />}
-      </StyledSwatch>
+      </Swatch>
     </Tooltip>
   );
 }


### PR DESCRIPTION
## Context

Sometimes in safari this would happen: 
https://user-images.githubusercontent.com/58738530/135152882-c6aba1cb-0fad-4cd4-b5af-9307e84aa656.gif 


## Summary

Where disabled swatch tooltips (gradients for text elements, for example) would get stuck open. Only happens in Safari. Only happens on the color swatches. 

## Relevant Technical Choices

So, after doing some digging it appears that the `disabled` button `Swatch` elements in Safari were swallowing up the pointer event and preventing the `Tooltip`'s `onPointerLeave` from firing (sometimes, not every time). It feels likely that this is due to the 💅  fancy styles happening to get the swatches to look right - with various pseudo classes. This is solved by adding `pointer-events: none` to both the button when it's disabled and also the `:after` pseudo class for buttons that are enabled.  As it's only a problem in the swatch it felt better to solve for this at the swatch level rather than impact the whole tooltip - especially since it would mean swapping to a less performant event set for tracking the cursor. 

While in there trying to figure out what was going on I added in some swatches wrapped in tooltips to storybook, decided to leave them for testing/debugging. Also noticed some redundant props/styles so took those out. 

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

Now in Safari if you hover over some disabled color swatches they should close when you are no longer hovering on the swatch. 

![safari swatch tooltips](https://user-images.githubusercontent.com/10720454/137040723-d901f6b7-dd8c-4fca-b105-2d4fd8418b83.gif)


## Testing Instructions

Verify that the swatch tooltips don't get stuck open any more.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9188 
