### PR TITLE
Video Optimization: Reuse existing resource if exists

### DIFF
--- a/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
@@ -19,9 +19,11 @@
  */
 import { act, renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
+
 /**
  * Internal dependencies
  */
+import APIContext from '../../../api/context';
 import StoryContext from '../../../story/context';
 import useProcessMedia from '../useProcessMedia';
 
@@ -86,14 +88,23 @@ const uploadMedia = (
   }
 };
 
+const getOptimizedMediaById = jest.fn();
+
 function setup() {
+  const apiContextValue = {
+    actions: {
+      getOptimizedMediaById,
+    },
+  };
   const storyContextValue = {
     actions: { updateElementsByResourceId },
   };
   const wrapper = ({ children }) => (
-    <StoryContext.Provider value={storyContextValue}>
-      {children}
-    </StoryContext.Provider>
+    <APIContext.Provider value={apiContextValue}>
+      <StoryContext.Provider value={storyContextValue}>
+        {children}
+      </StoryContext.Provider>
+    </APIContext.Provider>
   );
 
   const uploadVideoPoster = jest.fn();
@@ -126,6 +137,29 @@ function setup() {
 
 describe('useProcessMedia', () => {
   describe('optimizeVideo', () => {
+    it('should reuse already existing optimized video', async () => {
+      getOptimizedMediaById.mockImplementationOnce(() => ({
+        id: 456,
+        src: 'http://www.google.com/foo-optimized.mp4',
+      }));
+
+      const { optimizeVideo, uploadVideoPoster, updateMedia } = setup();
+      act(() => {
+        optimizeVideo({
+          resource: {
+            src: 'http://www.google.com/foo.mov',
+            id: 123,
+            mimeType: 'video/quicktime',
+          },
+        });
+      });
+      await waitFor(() => {
+        expect(getOptimizedMediaById).toHaveBeenCalledWith(123);
+        expect(uploadVideoPoster).not.toHaveBeenCalled();
+        expect(updateMedia).not.toHaveBeenCalled();
+      });
+    });
+
     it('should process video file', async () => {
       const { optimizeVideo, uploadVideoPoster, updateMedia } = setup();
       act(() => {

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -26,6 +26,7 @@ import {
 /**
  * Internal dependencies
  */
+import useAPI from '../../api/useAPI';
 import useStory from '../../story/useStory';
 
 function useProcessMedia({
@@ -35,6 +36,9 @@ function useProcessMedia({
   updateMedia,
   deleteMediaElement,
 }) {
+  const {
+    actions: { getOptimizedMediaById },
+  } = useAPI();
   const { updateElementsByResourceId } = useStory((state) => ({
     updateElementsByResourceId: state.actions.updateElementsByResourceId,
   }));
@@ -145,7 +149,15 @@ function useProcessMedia({
         });
       };
 
-      const process = async () => {
+      (async () => {
+        const optimizedResource = await getOptimizedMediaById(resourceId);
+
+        // This video was optimized before, no need to optimize it again.
+        if (optimizedResource) {
+          updateExistingElements(resourceId, optimizedResource);
+          return;
+        }
+
         let file = false;
         try {
           file = await fetchRemoteFile(url, mimeType);
@@ -163,11 +175,11 @@ function useProcessMedia({
             web_stories_is_muted: oldResource.isMuted,
           },
         });
-      };
-      return process();
+      })();
     },
     [
       copyResourceData,
+      getOptimizedMediaById,
       uploadMedia,
       uploadVideoPoster,
       updateVideoIsMuted,

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -101,7 +101,7 @@ export async function getOptimizedMediaById(config, mediaId) {
   const result = await apiFetch({ path });
 
   if (result?.meta?.web_stories_optimized_id) {
-    return getMediaById(config, result?.meta?.web_stories_optimized_id);
+    return getMediaById(config, result.meta.web_stories_optimized_id);
   }
 
   return null;

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -74,7 +74,7 @@ export function getMedia(
  *
  * @param {Object} config Configuration object.
  * @param {number} mediaId Media ID.
- * @return {Promise} Media object promise.
+ * @return {Promise<import('@web-stories-wp/media').Resource>} Media object promise.
  */
 export function getMediaById(config, mediaId) {
   const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
@@ -86,12 +86,34 @@ export function getMediaById(config, mediaId) {
 }
 
 /**
+ * Get the optimized variant of a given media resource.
+ *
+ * @param {Object} config Configuration object.
+ * @param {number} mediaId Media ID.
+ * @return {Promise<import('@web-stories-wp/media').Resource>} Media resource if found, null otherwise.
+ */
+export async function getOptimizedMediaById(config, mediaId) {
+  const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
+    context: 'edit',
+    _fields: 'meta.web_stories_optimized_id',
+  });
+
+  const result = await apiFetch({ path });
+
+  if (result?.meta?.web_stories_optimized_id) {
+    return getMediaById(config, result?.meta?.web_stories_optimized_id);
+  }
+
+  return null;
+}
+
+/**
  * Upload file to via REST API.
  *
  * @param {Object} config Configuration object.
  * @param {File} file Media File to Save.
  * @param {?Object} additionalData Additional data to include in the request.
- * @return {Promise} Media Object Promise.
+ * @return {Promise<import('@web-stories-wp/media').Resource>} Media resource.
  */
 export function uploadMedia(config, file, additionalData) {
   // Create upload payload


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Previously, when the same video has been used in multiple stories and you go edit every story to optimize the video, multiple optimized versions have been generated instead of just reusing the existing version.

## Summary

<!-- A brief description of what this PR does. -->

When optimizing an existing video via the checklist, the editor now first checks whether an optimized version of the resource already exists and just uses that if the case.

## Relevant Technical Choices

<!-- Please describe your changes. -->

* New `getOptimizedMediaById` API callback to find the optimized version of an existing resource.
* JSDoc improvements
* Updates tests

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. In the WordPress media library, upload a large video
2. Create a new story ("Story A") and insert the video there
3. Create another new story ("Story B") and insert the video there as well
3. In story A, add some empty pages so that the checklist shows up
4. In story A, optimize the video via the checklist
5. Preview story A, view source, and note down the video URL there
5. In story B, optimize the video via the checklist
6. Verify that the second "optimization" does not result in a video upload being started, but the checklist warning disappearing
7. Preview story B, view source, verify that video URL is the same as for the one in story A


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9384
