### PR TITLE
Quick Actions: Add sticker quick actions

### DIFF
--- a/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
@@ -139,6 +139,11 @@ const VIDEO_ELEMENT = {
   type: 'video',
 };
 
+const STICKER_ELEMENT = {
+  id: 'sticker-element-id',
+  type: 'sticker',
+};
+
 const resetElementAction = expect.objectContaining({
   label: ACTIONS.RESET_ELEMENT.text,
   onClick: expect.any(Function),
@@ -163,12 +168,7 @@ const defaultQuickActions = [
   }),
 ];
 
-const foregroundImageQuickActions = [
-  expect.objectContaining({
-    label: ACTIONS.REPLACE_MEDIA.text,
-    onClick: expect.any(Function),
-    Icon: PictureSwap,
-  }),
+const foregroundCommonActions = [
   expect.objectContaining({
     label: ACTIONS.ADD_ANIMATION.text,
     onClick: expect.any(Function),
@@ -179,6 +179,15 @@ const foregroundImageQuickActions = [
     onClick: expect.any(Function),
     Icon: Link,
   }),
+];
+
+const foregroundImageQuickActions = [
+  expect.objectContaining({
+    label: ACTIONS.REPLACE_MEDIA.text,
+    onClick: expect.any(Function),
+    Icon: PictureSwap,
+  }),
+  ...foregroundCommonActions,
 ];
 
 const foregroundImageQuickActionsWithClear = [
@@ -192,16 +201,7 @@ const shapeQuickActions = [
     onClick: expect.any(Function),
     Icon: Bucket,
   }),
-  expect.objectContaining({
-    label: ACTIONS.ADD_ANIMATION.text,
-    onClick: expect.any(Function),
-    Icon: CircleSpeed,
-  }),
-  expect.objectContaining({
-    label: ACTIONS.ADD_LINK.text,
-    onClick: expect.any(Function),
-    Icon: Link,
-  }),
+  ...foregroundCommonActions,
 ];
 
 const shapeQuickActionsWithClear = [...shapeQuickActions, resetElementAction];
@@ -217,21 +217,7 @@ const textQuickActions = [
     onClick: expect.any(Function),
     Icon: LetterTLargeLetterTSmall,
   }),
-  expect.objectContaining({
-    label: ACTIONS.AUTO_STYLE_TEXT.text,
-    onClick: expect.any(Function),
-    Icon: ColorBucket,
-  }),
-  expect.objectContaining({
-    label: ACTIONS.ADD_ANIMATION.text,
-    onClick: expect.any(Function),
-    Icon: CircleSpeed,
-  }),
-  expect.objectContaining({
-    label: ACTIONS.ADD_LINK.text,
-    onClick: expect.any(Function),
-    Icon: Link,
-  }),
+  ...foregroundCommonActions,
 ];
 const textQuickActionsWithClear = [...textQuickActions, resetElementAction];
 
@@ -262,6 +248,13 @@ const videoQuickActions = [
 ];
 
 const videoQuickActionsWithClear = [...videoQuickActions, resetElementAction];
+
+const stickerQuickActions = [...foregroundCommonActions];
+
+const stickerQuickActionsWithClear = [
+  ...stickerQuickActions,
+  resetElementAction,
+];
 
 describe('useQuickActions', () => {
   let highlight;
@@ -834,6 +827,70 @@ describe('useQuickActions', () => {
       result.current[4].onClick(mockClickEvent);
       expect(mockUpdateElementsById).toHaveBeenCalledWith({
         elementIds: [VIDEO_ELEMENT.id],
+        properties: expect.any(Function),
+      });
+    });
+  });
+
+  describe('sticker element selected', () => {
+    beforeEach(() => {
+      mockUseStory.mockReturnValue({
+        currentPage: {
+          elements: [BACKGROUND_ELEMENT, STICKER_ELEMENT],
+        },
+        selectedElementAnimations: [
+          {
+            target: [STICKER_ELEMENT.id],
+          },
+        ],
+        selectedElements: [STICKER_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
+      });
+    });
+
+    it('should return the quick actions', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      expect(result.current).toStrictEqual(stickerQuickActionsWithClear);
+    });
+
+    it('should set the correct highlight', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      result.current[0].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: STICKER_ELEMENT.id,
+        highlight: states.ANIMATION,
+      });
+
+      result.current[1].onClick(mockClickEvent);
+      expect(highlight).toStrictEqual({
+        elementId: STICKER_ELEMENT.id,
+        highlight: states.LINK,
+      });
+    });
+
+    it(`\`${ACTIONS.RESET_ELEMENT.text}\` action should not be present if element has no animations`, () => {
+      mockUseStory.mockReturnValue({
+        currentPage: {
+          elements: [BACKGROUND_ELEMENT, STICKER_ELEMENT],
+        },
+        selectedElementAnimations: [],
+        selectedElements: [STICKER_ELEMENT],
+        updateElementsById: mockUpdateElementsById,
+      });
+
+      const { result } = renderHook(() => useQuickActions());
+
+      expect(result.current[3]).toBeUndefined();
+    });
+
+    it('clicking `reset element` should update the element', () => {
+      const { result } = renderHook(() => useQuickActions());
+
+      result.current[2].onClick(mockClickEvent);
+      expect(mockUpdateElementsById).toHaveBeenCalledWith({
+        elementIds: [STICKER_ELEMENT.id],
         properties: expect.any(Function),
       });
     });

--- a/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/test/useQuickActions.js
@@ -217,6 +217,11 @@ const textQuickActions = [
     onClick: expect.any(Function),
     Icon: LetterTLargeLetterTSmall,
   }),
+  expect.objectContaining({
+    label: ACTIONS.AUTO_STYLE_TEXT.text,
+    onClick: expect.any(Function),
+    Icon: ColorBucket,
+  }),
   ...foregroundCommonActions,
 ];
 const textQuickActionsWithClear = [...textQuickActions, resetElementAction];

--- a/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
+++ b/packages/story-editor/src/app/highlights/quickActions/useQuickActions.js
@@ -656,6 +656,8 @@ const useQuickActions = () => {
       return textActions;
     case ELEMENT_TYPES.VIDEO:
       return videoActions;
+    case ELEMENT_TYPES.STICKER:
+      return foregroundCommonActions;
     default:
       return [];
   }


### PR DESCRIPTION
## Context

Stickers didn't have quick actions

## Summary

Add quick action menu for stickers

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

<img src="https://user-images.githubusercontent.com/22185279/137540821-d41d9fe0-0b7c-4b79-bdb5-a0d9fc93458a.gif" height="400px" />

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add a sticker to the canvas
2. Click on the sticker. Should see two actions: `Add animation` and `Add link`
3. Click the `Add animation` action. The animation panel should get highlighted
4. Click the `Add link` action. The link panel should get highlighted
5. Both of these should not make the sticker lose focus
6. Add some styles to the sticker (ex: reduce the opacity). Should see a new quick action appear: `Reset element`
7. Click that action. Should see the styles reset to their original values (animations should be removed as well). A snackbar will show.
8. Clicking the `undo` button in the snackbar will re-apply those styles.


## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #8933
