### PR TITLE
Karma Tests: Enable taxonomies integration test

### DIFF
--- a/packages/story-editor/src/components/panels/document/taxonomies/karma/taxonomies.karma.js
+++ b/packages/story-editor/src/components/panels/document/taxonomies/karma/taxonomies.karma.js
@@ -131,10 +131,7 @@ describe('Categories & Tags Panel', () => {
         // TODO: 9058 - validate new category exists on story once category is checked when added.
       });
 
-      // TODO: #9063
-      // disable reason: dropdown doesn't close unless the tests are slowed down
-      // eslint-disable-next-line jasmine/no-disabled-tests
-      xit('should add a new category as a child of an existing category', async () => {
+      it('should add a new category as a child of an existing category', async () => {
         await openCategoriesAndTagsPanel();
         const categoriesAndTags =
           fixture.editor.inspector.documentPanel.categoriesAndTags;
@@ -152,28 +149,17 @@ describe('Categories & Tags Panel', () => {
         await fixture.events.keyboard.type('deer');
         await fixture.events.click(categoriesAndTags.parentDropdownButton);
 
-        await waitFor(() =>
-          fixture.screen.getByRole('option', {
-            name: 'hierarchical_term_Booger',
-          })
-        );
         await fixture.events.click(
           fixture.screen.getByRole('option', {
-            name: 'hierarchical_term_Booger',
+            name: 'Booger',
           })
         );
-        await waitFor(() =>
-          fixture.screen
-            .queryByRole('option', {
-              name: 'hierarchical_term_Booger',
-            })
-            .toBeNull()
-        );
+
         await fixture.events.click(categoriesAndTags.addNewCategoryButton);
         // validate new checkbox was added
         const finalCategories = categoriesAndTags.categories;
         initialCategories.map((checkbox) =>
-          expect(checkbox.name).not.toBe('hierarchical_term_deer')
+          expect(checkbox.name).not.toBe('deer')
         );
         expect(finalCategories.length).toBe(initialCategories.length + 1);
         expect(


### PR DESCRIPTION
## Summary

Enable category integration test that was disabled.

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9063
