### PR TITLE
Checklist: Copy updates for low resolution checks

### DIFF
--- a/packages/story-editor/src/components/checklist/checks/videoElementResolution.js
+++ b/packages/story-editor/src/components/checklist/checks/videoElementResolution.js
@@ -24,14 +24,11 @@ import { useMemo, useCallback } from '@web-stories-wp/react';
  */
 import { useStory } from '../../../app';
 import { useHighlights } from '../../../app/highlights';
-import { DESIGN_COPY } from '../constants';
+import { DESIGN_COPY, MIN_VIDEO_HEIGHT, MIN_VIDEO_WIDTH } from '../constants';
 import { filterStoryElements } from '../utils';
 import { useRegisterCheck } from '../countContext';
 import { useIsChecklistMounted } from '../popupMountedContext';
 import VideoChecklistCard from './shared/videoChecklistCard';
-
-const MIN_VIDEO_HEIGHT = 480;
-const MIN_VIDEO_WIDTH = 852;
 
 export function videoElementResolution(element) {
   if (element.type !== 'video') {

--- a/packages/story-editor/src/components/checklist/constants.js
+++ b/packages/story-editor/src/components/checklist/constants.js
@@ -278,7 +278,7 @@ export const DESIGN_COPY = {
     footer: sprintf(
       /* translators: 1: minimum video resolution. 2: minimum video width x minimum video height in pixels. */
       __(
-        'Consider using a minimum resolution of %1$d (%2$d) to represent portrait videos',
+        'Consider using a minimum resolution of %1$s (%2$s) to represent portrait videos',
         'web-stories'
       ),
       `${MIN_VIDEO_RESOLUTION}p`,

--- a/packages/story-editor/src/components/checklist/constants.js
+++ b/packages/story-editor/src/components/checklist/constants.js
@@ -234,24 +234,23 @@ export const DESIGN_COPY = {
     ),
   },
   imageResolutionTooLow: {
-    title: sprintf(
-      /* translators: %s: minimum image size width x minimum image size height. */
-      __('Upload a higher resolution image to at least %s', 'web-stories'),
-      `${IMAGE_SIZE_WIDTH}x${IMAGE_SIZE_HEIGHT}px`
-    ),
+    title: __('Increase image resolution', 'web-stories'),
     footer: (
       <>
         <li>
-          {sprintf(
-            /* translators: %s: minimum image size width x minimum image size height. */
-            __('Use %s for a full-screen image', 'web-stories'),
-            `${IMAGE_SIZE_WIDTH}x${IMAGE_SIZE_HEIGHT}px`
+          {__(
+            'Use larger resolution (2x or 3x) images for best appearance on screens with high pixel density',
+            'web-stories'
           )}
         </li>
         <li>
-          {__(
-            'Consider similar pixel density for cropped images',
-            'web-stories'
+          {sprintf(
+            /* translators: %s: minimum image size width x minimum image size height. */
+            __(
+              'For full-screen images, use a resolution of at least %s',
+              'web-stories'
+            ),
+            `${IMAGE_SIZE_WIDTH}x${IMAGE_SIZE_HEIGHT}px`
           )}
         </li>
       </>
@@ -277,14 +276,13 @@ export const DESIGN_COPY = {
   videoResolutionTooLow: {
     title: __('Increase video resolution', 'web-stories'),
     footer: sprintf(
-      /* translators: 1: minimum video resolution. 2: minimum video width. 3: minimum video height. */
+      /* translators: 1: minimum video resolution. 2: minimum video width x minimum video height in pixels. */
       __(
-        'Consider using a minimum resolution of %1$dp (%2$d×%3$dpx) to represent portrait videos.',
+        'Consider using a minimum resolution of %1$d (%2$d) to represent portrait videos',
         'web-stories'
       ),
-      MIN_VIDEO_RESOLUTION,
-      MIN_VIDEO_WIDTH,
-      MIN_VIDEO_HEIGHT
+      `${MIN_VIDEO_RESOLUTION}p`,
+      `${MIN_VIDEO_WIDTH}x${MIN_VIDEO_HEIGHT}px`
     ),
   },
   videoTooLong: {

--- a/packages/story-editor/src/components/checklist/constants.js
+++ b/packages/story-editor/src/components/checklist/constants.js
@@ -42,6 +42,8 @@ const MIN_TAP_REGION_WIDTH = 48;
 export const MAX_LINKS_PER_PAGE = 3;
 const MAX_VIDEO_RESOLUTION = 720;
 const MIN_VIDEO_RESOLUTION = 480;
+export const MIN_VIDEO_HEIGHT = 480;
+export const MIN_VIDEO_WIDTH = 852;
 const MIN_VIDEO_FPS = 24;
 export const FEATURED_MEDIA_RESOURCE_MIN_WIDTH = 640;
 export const FEATURED_MEDIA_RESOURCE_MIN_HEIGHT = 853;
@@ -273,15 +275,16 @@ export const DESIGN_COPY = {
     ),
   },
   videoResolutionTooLow: {
-    title: sprintf(
-      /* translators: %s: minimum video resolution. */
-      __('Increase video resolution to at least %s', 'web-stories'),
-      `${MIN_VIDEO_RESOLUTION}p`
-    ),
+    title: __('Increase video resolution', 'web-stories'),
     footer: sprintf(
-      /* translators: %s: minimum video resolution. */
-      __('Ensure your video has a minimum resolution of %s', 'web-stories'),
-      `${MIN_VIDEO_RESOLUTION}p`
+      /* translators: 1: minimum video resolution. 2: minimum video width. 3: minimum video height. */
+      __(
+        'Consider using a minimum resolution of %1$dp (%2$d×%3$dpx) to represent portrait videos.',
+        'web-stories'
+      ),
+      MIN_VIDEO_RESOLUTION,
+      MIN_VIDEO_WIDTH,
+      MIN_VIDEO_HEIGHT
     ),
   },
   videoTooLong: {


### PR DESCRIPTION
## Context

Some copy was overlooked as the checklist morphed. Thanks to Pascal and users for reading and making note that it was redundant and unhelpful. 

## Summary

Updates the copy for image and videos with low resolution. Think the phrasing works well for singular or plural since it's indefinite. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

Split out work mentioned as an aside in #9401 to take scale into consideration for image resolution (#9439)

## User-facing changes

| Old | New |
| --- | --- |
| ![Screen Shot 2021-10-18 at 4 56 57 PM](https://user-images.githubusercontent.com/10720454/137822029-4be6781f-0342-4087-8a09-a4f45bd477fe.png) | ![Screen Shot 2021-10-18 at 4 46 23 PM](https://user-images.githubusercontent.com/10720454/137821944-4bb2b4ca-a521-40f7-9141-9a1a0e8d18c4.png) |


## Testing Instructions

Have a tiny image and a tiny video and see the resolution check get flagged and shows new copy.

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

No

### Does this PR change what data or activity we track or use?

No

### Does this PR have a legal-related impact?

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9400 
Fixes #9401 
