### PR TITLE
Improve handling of URLs containing commas

### DIFF
--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -394,7 +394,10 @@ trait Sanitization_Utils {
 
 			$entries_by_widths = [];
 
-			$entries = explode( ',', $srcset );
+			$matches = [];
+			preg_match_all( '/((?<entry>[^ ]+ [\d]+w),?)/', $srcset, $matches );
+
+			$entries = $matches['entry'] ?? [];
 
 			foreach ( $entries as $entry ) {
 				$entry_data = explode( ' ', $entry );

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -392,12 +392,16 @@ trait Sanitization_Utils {
 				continue;
 			}
 
-			$entries_by_widths = [];
-
 			$matches = [];
+
+			// Matches every srcset entry (consisting of a URL and a width descriptor) within `srcset=""`.
+			// Not using explode(',') to not break with URLs containing commas.
+			// Given "foo1,2/image.png 123w, foo2,3/image.png 456w", the named capture group "entry"
+			// will contain "foo1,2/image.png 123w" and "foo2,3/image.png 456w", without the trailing commas.
 			preg_match_all( '/((?<entry>[^ ]+ [\d]+w),?)/', $srcset, $matches );
 
-			$entries = $matches['entry'] ?? [];
+			$entries           = $matches['entry'] ?? [];
+			$entries_by_widths = [];
 
 			foreach ( $entries as $entry ) {
 				$entry_data = explode( ' ', $entry );

--- a/packages/media/src/calculateSrcSet.js
+++ b/packages/media/src/calculateSrcSet.js
@@ -46,7 +46,9 @@ function calculateSrcSet(resource) {
         []
       )
       .filter((s) => s && s.source_url && s.width)
-      .map((s) => `${encodeURI(s.source_url)} ${s.width}w`)
+      .map(
+        (s) => `${encodeURI(s.source_url).replaceAll(',', '%2C')} ${s.width}w`
+      )
       .join(',')
   );
 }

--- a/packages/media/src/test/calculateSrcSet.js
+++ b/packages/media/src/test/calculateSrcSet.js
@@ -304,4 +304,39 @@ describe('calculateSrcSet', () => {
       'image.jpg 1000w,image-768x1024.jpg 768w,image-225x300.jpg 225w,image-150x200.jpg 150w'
     );
   });
+
+  it('should not break image URLs with commas in them', () => {
+    const resource = {
+      src: 'image.jpg',
+      width: 640,
+      height: 853,
+      sizes: {
+        thumbnail: {
+          width: 150,
+          height: 200,
+          source_url:
+            'https://example.com/images/w_150,h_200,c_scale/image.jpg?_i=AA',
+        },
+        medium: {
+          width: 225,
+          height: 300,
+          source_url:
+            'https://example.com/images/w_225,h_300,c_scale/image.jpg?_i=AA',
+        },
+        full: {
+          width: 640,
+          height: 853,
+          source_url:
+            'https://example.com/images/w_640,h_853,c_scale/image.jpg?_i=AA',
+        },
+      },
+    };
+
+    const srcSet = calculateSrcSet(resource);
+    expect(srcSet).toBe(
+      'https://example.com/images/w_640%2Ch_853%2Cc_scale/image.jpg?_i=AA 640w,' +
+        'https://example.com/images/w_225%2Ch_300%2Cc_scale/image.jpg?_i=AA 225w,' +
+        'https://example.com/images/w_150%2Ch_200%2Cc_scale/image.jpg?_i=AA 150w'
+    );
+  });
 });

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -387,6 +387,24 @@ class Story_Sanitizer extends TestCase {
 	}
 
 	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::sanitize_srcset
+	 */
+	public function test_sanitize_srcset_commas() {
+		$source = '<html><head></head><body><amp-story><amp-img src="https://example.com/image.jpg" width="100" height="100" srcset="https://example.com/image/1000,1000/image.jpg 1000w,https://example.com/image/768,1024/image-768x1024.jpg 768w,https://example.com/image/225,300/image-225x300.jpg 225w,https://example.com/image/150,200/image-150x200.jpg 150w"></amp-img></amp-story></body></html>';
+
+		$args = [
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertStringContainsString( 'srcset="https://example.com/image/1000,1000/image.jpg 1000w, https://example.com/image/768,1024/image-768x1024.jpg 768w, https://example.com/image/225,300/image-225x300.jpg 225w, https://example.com/image/150,200/image-150x200.jpg 150w"', $actual );
+	}
+
+	/**
 	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::sanitize_amp_story_page_outlink
 	 */
 	public function test_sanitize_amp_story_page_outlink() {


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

There's a conflict with Cloudinary because that service generates URLs with commas in them, such as `https://res.cloudinary.com/dvo1qnusu/images/w_2560,h_1440/f_auto,_auto/v1634657791/pexels-mike-170809_14480b628/pexels-mike-170809_14480b628.jpg?_i=AA`

## Summary

<!-- A brief description of what this PR does. -->

This PR adds extra hardening for dealing with URLs containing commas

## Relevant Technical Choices

<!-- Please describe your changes. -->

* Escape commas on output
* Add extra hardening to story sanitizer

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9450
