### PR TITLE
Pre-Publish Checklist: Fix double scrollbars

### DIFF
--- a/packages/story-editor/src/components/tablist/styles.js
+++ b/packages/story-editor/src/components/tablist/styles.js
@@ -138,11 +138,12 @@ export const PanelWrapper = styled.div`
         }
       }
 
-      * ${TabPanel} {
+      ${ScrollableContent} {
         height: 560px;
-        padding: 0 0 16px 16px;
-        overflow-y: scroll;
-        visibility: visible;
+
+        ${TabPanel} {
+          visibility: visible;
+        }
       }
     `};
 `;
@@ -182,18 +183,19 @@ export const Badge = styled.div`
 `;
 
 export const ScrollableContent = styled.div`
+  height: 0;
   max-height: ${({ maxHeight }) => (maxHeight ? `calc(${maxHeight})` : 'none')};
   overflow-y: ${({ maxHeight }) => (maxHeight ? 'scroll' : 'hidden')};
+  transition: height 300ms ease-in;
 `;
 
 export const TabPanel = styled.div`
-  height: 0;
   padding: 0;
   visibility: hidden;
-  overflow-y: hidden;
-  overflow-x: hidden;
+  overflow: hidden;
   background: ${({ theme }) => theme.colors.bg.primary};
   transition: all 300ms ease-in;
+  margin: 0 0 16px 16px;
 
   ${themeHelpers.scrollbarCSS};
 `;

--- a/packages/story-editor/src/components/tablist/tablistPanel.js
+++ b/packages/story-editor/src/components/tablist/tablistPanel.js
@@ -88,7 +88,7 @@ const TablistPanel = ({
           </Badge>
         </TabButton>
       </TabButtonWrapper>
-      <ScrollableContent maxHeight={maxHeight}>
+      <ScrollableContent aria-hidden={!isExpanded} maxHeight={maxHeight}>
         <TabPanel
           id={panelId}
           aria-labelledby={`${title}-${panelId}`}


### PR DESCRIPTION
## Context

Double scrollbars are not cool.

## Summary

Only show one scrollbar if content is scrollable in the pre-publish checklist.

## Relevant Technical Choices

n/a

## To-do

n/a

## User-facing changes

|Before|After|
|--|--|
|![double-scrollbars](https://user-images.githubusercontent.com/22185279/138092506-6a57230f-cf6b-4b75-8c7b-6c7e2190b38e.gif)|![single-scrollbar](https://user-images.githubusercontent.com/22185279/138092526-60b974ca-86f7-452e-820e-53e4e96f6ae3.gif)|

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open editor
2. Add stuff to the story until you get many issues in the checklist
3. Open the checklist
4. Should not be double scrollbars. Double check by shrinking the height of the screen to force hidden double scrollbars to appear (if there were any).

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9404
