### PR TITLE
Settings: Add e2e tests for non-admin users

### DIFF
--- a/packages/e2e-test-utils/src/disableCheckbox.js
+++ b/packages/e2e-test-utils/src/disableCheckbox.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default async function disableCheckbox(selector) {
+  await page.waitForSelector(selector);
+  await page.evaluate((checkbox) => {
+    const node = document.querySelector(checkbox);
+    if (node.checked) {
+      node.click();
+    }
+  }, selector);
+
+  await expect(page).not.toMatchElement(`${selector}:checked`);
+}

--- a/packages/e2e-test-utils/src/disableCheckbox.js
+++ b/packages/e2e-test-utils/src/disableCheckbox.js
@@ -22,5 +22,5 @@ export default async function disableCheckbox(selector) {
     }
   }, selector);
 
-  await expect(page).not.toMatchElement(`${selector}:checked`);
+  await expect(page).toMatchElement(`${selector}:not(:checked)`);
 }

--- a/packages/e2e-test-utils/src/enableCheckbox.js
+++ b/packages/e2e-test-utils/src/enableCheckbox.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export default async function enableCheckbox(selector) {
+  await page.waitForSelector(selector);
+  await page.evaluate((checkbox) => {
+    const node = document.querySelector(checkbox);
+    if (!node.checked) {
+      node.click();
+    }
+  }, selector);
+
+  await expect(page).toMatchElement(`${selector}:checked`);
+}

--- a/packages/e2e-test-utils/src/index.js
+++ b/packages/e2e-test-utils/src/index.js
@@ -51,6 +51,8 @@ export { default as minWPVersionRequired } from './minWPVersionRequired';
 export { default as visitBlockWidgetScreen } from './visitBlockWidgetScreen';
 export { default as insertWidget } from './insertWidget';
 export { default as triggerHighPriorityChecklistSection } from './triggerHighPriorityChecklistSection';
+export { default as disableCheckbox } from './disableCheckbox';
+export { default as enableCheckbox } from './enableCheckbox';
 export {
   getEditedPostContent,
   setPostContent,

--- a/packages/e2e-tests/src/specs/dashboard/publisherLogo.js
+++ b/packages/e2e-tests/src/specs/dashboard/publisherLogo.js
@@ -22,6 +22,7 @@ import {
   uploadPublisherLogo,
   visitSettings,
   withExperimentalFeatures,
+  withUser,
 } from '@web-stories-wp/e2e-test-utils';
 
 const ERROR_TEXT =
@@ -111,5 +112,56 @@ describe('Publisher logo', () => {
 
     uploadedFiles.push(logoOneName);
     uploadedFiles.push(logoTwoName);
+  });
+
+  it('should give me the ability to upload publisher logos', async () => {
+    await visitSettings();
+
+    // verify no publisher logos are shown
+    await expect(page).toMatchElement(
+      '[data-testid="publisher-logos-container"]'
+    );
+  });
+
+  describe('editor user', () => {
+    // eslint-disable-next-line jest/require-hook
+    withUser('editor', 'password');
+
+    it('should not give me the ability to upload publisher logos', async () => {
+      await visitSettings();
+
+      // verify no publisher logos are shown
+      await expect(page).not.toMatchElement(
+        '[data-testid="publisher-logos-container"]'
+      );
+    });
+  });
+
+  describe('author user', () => {
+    // eslint-disable-next-line jest/require-hook
+    withUser('author', 'password');
+
+    it('should not give me the ability to upload publisher logos', async () => {
+      await visitSettings();
+
+      // verify no publisher logos are shown
+      await expect(page).not.toMatchElement(
+        '[data-testid="publisher-logos-container"]'
+      );
+    });
+  });
+
+  describe('contributor user', () => {
+    // eslint-disable-next-line jest/require-hook
+    withUser('author', 'password');
+
+    it('should not give me the ability to upload publisher logos', async () => {
+      await visitSettings();
+
+      // verify no publisher logos are shown
+      await expect(page).not.toMatchElement(
+        '[data-testid="publisher-logos-container"]'
+      );
+    });
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/publisherLogo.js
+++ b/packages/e2e-tests/src/specs/dashboard/publisherLogo.js
@@ -153,7 +153,7 @@ describe('Publisher logo', () => {
 
   describe('contributor user', () => {
     // eslint-disable-next-line jest/require-hook
-    withUser('author', 'password');
+    withUser('contributor', 'password');
 
     it('should not give me the ability to upload publisher logos', async () => {
       await visitSettings();

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
@@ -18,6 +18,7 @@
  * External dependencies
  */
 import {
+  clickButton,
   disableCheckbox,
   enableCheckbox,
   visitSettings,
@@ -49,9 +50,7 @@ describe('Admin User', () => {
     await enableCheckbox(videoCacheCheckboxSelector);
   });
 
-  it('should give me the ability to see and update the telemetry checkbox', async () => {
-    await visitSettings();
-
+  it('should let me see and update the telemetry checkbox', async () => {
     await disableCheckbox(telemetryCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -59,9 +58,7 @@ describe('Admin User', () => {
     );
   });
 
-  it('should give me the ability to see and update the video optimization checkbox', async () => {
-    await visitSettings();
-
+  it('should let me see and update the video optimization checkbox', async () => {
     await disableCheckbox(videoOptimizationCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -69,13 +66,24 @@ describe('Admin User', () => {
     );
   });
 
-  it('should give me the ability to see and update the video cache checkbox', async () => {
-    await visitSettings();
-
+  it('should let me see and update the video cache checkbox', async () => {
     await disableCheckbox(videoCacheCheckboxSelector);
 
     await expect(page).toMatchElement(
       `${videoCacheCheckboxSelector}:not(:checked)`
+    );
+  });
+
+  it('should let me see and update the monetization settings', async () => {
+    await clickButton('button[aria-label="Monetization type"]', {
+      text: 'None',
+    });
+
+    await expect(page).toClick('button', { text: 'Google AdSense' });
+
+    await expect(page).toMatchElement(
+      'button[aria-label="Monetization type"]',
+      { text: 'Google AdSense' }
     );
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
@@ -21,7 +21,6 @@ import {
   disableCheckbox,
   enableCheckbox,
   visitSettings,
-  withUser,
 } from '@web-stories-wp/e2e-test-utils';
 
 /**
@@ -33,15 +32,13 @@ import {
   videoOptimizationCheckboxSelector,
 } from '../../../utils';
 
-describe('Author User', () => {
-  // eslint-disable-next-line jest/require-hook
-  withUser('author', 'password');
-
+describe('Admin User', () => {
   beforeEach(async () => {
     await visitSettings();
 
     await enableCheckbox(telemetryCheckboxSelector);
     await enableCheckbox(videoOptimizationCheckboxSelector);
+    await enableCheckbox(videoCacheCheckboxSelector);
   });
 
   afterEach(async () => {
@@ -49,16 +46,12 @@ describe('Author User', () => {
 
     await enableCheckbox(telemetryCheckboxSelector);
     await enableCheckbox(videoOptimizationCheckboxSelector);
-  });
-
-  it('should give me the ability to upload publisher logos', async () => {
-    // verify no publisher logos are shown
-    await expect(page).not.toMatchElement(
-      '[data-testid="publisher-logos-container"]'
-    );
+    await enableCheckbox(videoCacheCheckboxSelector);
   });
 
   it('should give me the ability to see and update the telemetry checkbox', async () => {
+    await visitSettings();
+
     await disableCheckbox(telemetryCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -67,6 +60,8 @@ describe('Author User', () => {
   });
 
   it('should give me the ability to see and update the video optimization checkbox', async () => {
+    await visitSettings();
+
     await disableCheckbox(videoOptimizationCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -74,7 +69,13 @@ describe('Author User', () => {
     );
   });
 
-  it('should not give me the ability to see other settings', async () => {
-    await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
+  it('should give me the ability to see and update the video cache checkbox', async () => {
+    await visitSettings();
+
+    await disableCheckbox(videoCacheCheckboxSelector);
+
+    await expect(page).toMatchElement(
+      `${videoCacheCheckboxSelector}:not(:checked)`
+    );
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
@@ -46,9 +46,9 @@ describe('Admin User', () => {
   afterEach(async () => {
     await visitSettings();
 
-    await enableCheckbox(telemetryCheckboxSelector);
-    await enableCheckbox(videoOptimizationCheckboxSelector);
-    await enableCheckbox(videoCacheCheckboxSelector);
+    await disableCheckbox(telemetryCheckboxSelector);
+    await disableCheckbox(videoOptimizationCheckboxSelector);
+    await disableCheckbox(videoCacheCheckboxSelector);
   });
 
   it('should let me see and update all settings', async () => {

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
@@ -55,25 +55,16 @@ describe('Admin User', () => {
     // verify that the telemetry checkbox can be changed
     await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${telemetryCheckboxSelector}:not(:checked)`
-    );
 
     // verify that the video optimization checkbox can be changed
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:checked`
     );
     await disableCheckbox(videoOptimizationCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${videoOptimizationCheckboxSelector}:not(:checked)`
-    );
 
     // verify that the video cache checkbox can be changed
     await expect(page).toMatchElement(`${videoCacheCheckboxSelector}:checked`);
     await disableCheckbox(videoCacheCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${videoCacheCheckboxSelector}:not(:checked)`
-    );
 
     // verify that the monetization settings can be changed
     await clickButton(monetizationDropdownSelector, {

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
@@ -47,7 +47,7 @@ describe('Admin User', () => {
     await visitSettings();
 
     await disableCheckbox(telemetryCheckboxSelector);
-    await disableCheckbox(videoOptimizationCheckboxSelector);
+    await enableCheckbox(videoOptimizationCheckboxSelector);
     await disableCheckbox(videoCacheCheckboxSelector);
   });
 

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
@@ -70,9 +70,18 @@ describe('Admin User', () => {
     await clickButton(monetizationDropdownSelector, {
       text: 'None',
     });
-    await expect(page).toClick('button', { text: 'Google AdSense' });
+    await expect(page).toClick('li', { text: 'Google AdSense' });
     await expect(page).toMatchElement(monetizationDropdownSelector, {
       text: 'Google AdSense',
+    });
+
+    // reset monetization setting
+    await clickButton(monetizationDropdownSelector, {
+      text: 'Google AdSense',
+    });
+    await expect(page).toClick('li', { text: 'None' });
+    await expect(page).toMatchElement(monetizationDropdownSelector, {
+      text: 'None',
     });
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/adminUser.js
@@ -28,6 +28,7 @@ import {
  * Internal dependencies
  */
 import {
+  monetizationDropdownSelector,
   telemetryCheckboxSelector,
   videoCacheCheckboxSelector,
   videoOptimizationCheckboxSelector,
@@ -50,40 +51,37 @@ describe('Admin User', () => {
     await enableCheckbox(videoCacheCheckboxSelector);
   });
 
-  it('should let me see and update the telemetry checkbox', async () => {
+  it('should let me see and update all settings', async () => {
+    // verify that the telemetry checkbox can be changed
+    await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${telemetryCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should let me see and update the video optimization checkbox', async () => {
+    // verify that the video optimization checkbox can be changed
+    await expect(page).toMatchElement(
+      `${videoOptimizationCheckboxSelector}:checked`
+    );
     await disableCheckbox(videoOptimizationCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should let me see and update the video cache checkbox', async () => {
+    // verify that the video cache checkbox can be changed
+    await expect(page).toMatchElement(`${videoCacheCheckboxSelector}:checked`);
     await disableCheckbox(videoCacheCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${videoCacheCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should let me see and update the monetization settings', async () => {
-    await clickButton('button[aria-label="Monetization type"]', {
+    // verify that the monetization settings can be changed
+    await clickButton(monetizationDropdownSelector, {
       text: 'None',
     });
-
     await expect(page).toClick('button', { text: 'Google AdSense' });
-
-    await expect(page).toMatchElement(
-      'button[aria-label="Monetization type"]',
-      { text: 'Google AdSense' }
-    );
+    await expect(page).toMatchElement(monetizationDropdownSelector, {
+      text: 'Google AdSense',
+    });
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
@@ -51,14 +51,14 @@ describe('Author User', () => {
     await enableCheckbox(videoOptimizationCheckboxSelector);
   });
 
-  it('should give me the ability to upload publisher logos', async () => {
+  it('should let me upload publisher logos', async () => {
     // verify no publisher logos are shown
     await expect(page).not.toMatchElement(
       '[data-testid="publisher-logos-container"]'
     );
   });
 
-  it('should give me the ability to see and update the telemetry checkbox', async () => {
+  it('should let me see and update the telemetry checkbox', async () => {
     await disableCheckbox(telemetryCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -66,7 +66,7 @@ describe('Author User', () => {
     );
   });
 
-  it('should give me the ability to see and update the video optimization checkbox', async () => {
+  it('should let me see and update the video optimization checkbox', async () => {
     await disableCheckbox(videoOptimizationCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -74,7 +74,7 @@ describe('Author User', () => {
     );
   });
 
-  it('should not give me the ability to see other settings', async () => {
+  it('should not let me see other settings', async () => {
     await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+  disableCheckbox,
+  enableCheckbox,
+  visitSettings,
+  withUser,
+} from '@web-stories-wp/e2e-test-utils';
+
+const telemetryCheckboxSelector =
+  'input[data-testid="telemetry-settings-checkbox"]';
+const videoOptimizationCheckboxSelector =
+  'input[data-testid="media-optimization-settings-checkbox"]';
+
+describe('Author User', () => {
+  // eslint-disable-next-line jest/require-hook
+  withUser('author', 'password');
+
+  beforeEach(async () => {
+    await visitSettings();
+
+    await disableCheckbox(telemetryCheckboxSelector);
+    await disableCheckbox(videoOptimizationCheckboxSelector);
+  });
+
+  afterEach(async () => {
+    await visitSettings();
+
+    await enableCheckbox(telemetryCheckboxSelector);
+    await enableCheckbox(videoOptimizationCheckboxSelector);
+  });
+
+  it('should give me the ability to upload publisher logos', async () => {
+    // verify no publisher logos are shown
+    await expect(page).not.toMatchElement(
+      '[data-testid="publisher-logos-container"]'
+    );
+  });
+
+  it('should give me the ability to see and update the telemetry checkbox', async () => {
+    await disableCheckbox(telemetryCheckboxSelector);
+
+    await expect(page).toMatchElement(
+      `${telemetryCheckboxSelector}:not(:checked)`
+    );
+  });
+
+  it('should give me the ability to see and update the video optimization checkbox', async () => {
+    await disableCheckbox(videoOptimizationCheckboxSelector);
+
+    await expect(page).toMatchElement(
+      `${videoOptimizationCheckboxSelector}:not(:checked)`
+    );
+  });
+});

--- a/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
@@ -49,7 +49,7 @@ describe('Author User', () => {
     await visitSettings();
 
     await disableCheckbox(telemetryCheckboxSelector);
-    await disableCheckbox(videoOptimizationCheckboxSelector);
+    await enableCheckbox(videoOptimizationCheckboxSelector);
   });
 
   it('should only let me see and update the telemetry and video optimization settings', async () => {

--- a/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
@@ -28,6 +28,7 @@ import {
  * Internal dependencies
  */
 import {
+  monetizationDropdownSelector,
   telemetryCheckboxSelector,
   videoCacheCheckboxSelector,
   videoOptimizationCheckboxSelector,
@@ -51,30 +52,28 @@ describe('Author User', () => {
     await enableCheckbox(videoOptimizationCheckboxSelector);
   });
 
-  it('should let me upload publisher logos', async () => {
-    // verify no publisher logos are shown
-    await expect(page).not.toMatchElement(
-      '[data-testid="publisher-logos-container"]'
-    );
-  });
-
-  it('should let me see and update the telemetry checkbox', async () => {
+  it('should only let me see and update the telemetry and video optimization settings', async () => {
+    // verify that the telemetry checkbox can be changed
+    await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${telemetryCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should let me see and update the video optimization checkbox', async () => {
+    // verify that the video optimization checkbox can be changed
+    await expect(page).toMatchElement(
+      `${videoOptimizationCheckboxSelector}:checked`
+    );
     await disableCheckbox(videoOptimizationCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should not let me see other settings', async () => {
+    // verify no other settings are showing
+    await expect(page).not.toMatchElement(
+      '[data-testid="publisher-logos-container"]'
+    );
+    await expect(page).not.toMatchElement(monetizationDropdownSelector);
     await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
@@ -56,18 +56,12 @@ describe('Author User', () => {
     // verify that the telemetry checkbox can be changed
     await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${telemetryCheckboxSelector}:not(:checked)`
-    );
 
     // verify that the video optimization checkbox can be changed
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:checked`
     );
     await disableCheckbox(videoOptimizationCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${videoOptimizationCheckboxSelector}:not(:checked)`
-    );
 
     // verify no other settings are showing
     await expect(page).not.toMatchElement(

--- a/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/authorUser.js
@@ -48,8 +48,8 @@ describe('Author User', () => {
   afterEach(async () => {
     await visitSettings();
 
-    await enableCheckbox(telemetryCheckboxSelector);
-    await enableCheckbox(videoOptimizationCheckboxSelector);
+    await disableCheckbox(telemetryCheckboxSelector);
+    await disableCheckbox(videoOptimizationCheckboxSelector);
   });
 
   it('should only let me see and update the telemetry and video optimization settings', async () => {

--- a/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
@@ -29,6 +29,7 @@ import {
  */
 import {
   telemetryCheckboxSelector,
+  videoCacheCheckboxSelector,
   videoOptimizationCheckboxSelector,
 } from '../../../utils';
 
@@ -39,7 +40,7 @@ describe('Contributor User', () => {
   beforeEach(async () => {
     await visitSettings();
 
-    await disableCheckbox(telemetryCheckboxSelector);
+    await enableCheckbox(telemetryCheckboxSelector);
   });
 
   afterEach(async () => {
@@ -63,7 +64,8 @@ describe('Contributor User', () => {
     );
   });
 
-  it('should give me the ability to see and update the video optimization checkbox', async () => {
+  it('should not give me the ability to see other settings', async () => {
     await expect(page).not.toMatchElement(videoOptimizationCheckboxSelector);
+    await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+  disableCheckbox,
+  enableCheckbox,
+  visitSettings,
+  withUser,
+} from '@web-stories-wp/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+  telemetryCheckboxSelector,
+  videoOptimizationCheckboxSelector,
+} from '../../../utils';
+
+describe('Contributor User', () => {
+  // eslint-disable-next-line jest/require-hook
+  withUser('contributor', 'password');
+
+  beforeEach(async () => {
+    await visitSettings();
+
+    await disableCheckbox(telemetryCheckboxSelector);
+  });
+
+  afterEach(async () => {
+    await visitSettings();
+
+    await enableCheckbox(telemetryCheckboxSelector);
+  });
+
+  it('should give me the ability to upload publisher logos', async () => {
+    // verify no publisher logos are shown
+    await expect(page).not.toMatchElement(
+      '[data-testid="publisher-logos-container"]'
+    );
+  });
+
+  it('should give me the ability to see and update the telemetry checkbox', async () => {
+    await disableCheckbox(telemetryCheckboxSelector);
+
+    await expect(page).toMatchElement(
+      `${telemetryCheckboxSelector}:not(:checked)`
+    );
+  });
+
+  it('should give me the ability to see and update the video optimization checkbox', async () => {
+    await expect(page).not.toMatchElement(videoOptimizationCheckboxSelector);
+  });
+});

--- a/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
@@ -49,14 +49,14 @@ describe('Contributor User', () => {
     await enableCheckbox(telemetryCheckboxSelector);
   });
 
-  it('should give me the ability to upload publisher logos', async () => {
+  it('should let me upload publisher logos', async () => {
     // verify no publisher logos are shown
     await expect(page).not.toMatchElement(
       '[data-testid="publisher-logos-container"]'
     );
   });
 
-  it('should give me the ability to see and update the telemetry checkbox', async () => {
+  it('should let me see and update the telemetry checkbox', async () => {
     await disableCheckbox(telemetryCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -64,7 +64,7 @@ describe('Contributor User', () => {
     );
   });
 
-  it('should not give me the ability to see other settings', async () => {
+  it('should not let me see other settings', async () => {
     await expect(page).not.toMatchElement(videoOptimizationCheckboxSelector);
     await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });

--- a/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
@@ -47,7 +47,7 @@ describe('Contributor User', () => {
   afterEach(async () => {
     await visitSettings();
 
-    await enableCheckbox(telemetryCheckboxSelector);
+    await disableCheckbox(telemetryCheckboxSelector);
   });
 
   it('should only let me see and update the telemetry setting', async () => {

--- a/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
@@ -54,9 +54,6 @@ describe('Contributor User', () => {
     // verify that the telemetry checkbox can be changed
     await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${telemetryCheckboxSelector}:not(:checked)`
-    );
 
     // verify no other settings are showing
     await expect(page).not.toMatchElement(

--- a/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/contributorUser.js
@@ -28,6 +28,7 @@ import {
  * Internal dependencies
  */
 import {
+  monetizationDropdownSelector,
   telemetryCheckboxSelector,
   videoCacheCheckboxSelector,
   videoOptimizationCheckboxSelector,
@@ -49,22 +50,19 @@ describe('Contributor User', () => {
     await enableCheckbox(telemetryCheckboxSelector);
   });
 
-  it('should let me upload publisher logos', async () => {
-    // verify no publisher logos are shown
-    await expect(page).not.toMatchElement(
-      '[data-testid="publisher-logos-container"]'
-    );
-  });
-
-  it('should let me see and update the telemetry checkbox', async () => {
+  it('should only let me see and update the telemetry setting', async () => {
+    // verify that the telemetry checkbox can be changed
+    await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${telemetryCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should not let me see other settings', async () => {
+    // verify no other settings are showing
+    await expect(page).not.toMatchElement(
+      '[data-testid="publisher-logos-container"]'
+    );
+    await expect(page).not.toMatchElement(monetizationDropdownSelector);
     await expect(page).not.toMatchElement(videoOptimizationCheckboxSelector);
     await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });

--- a/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
@@ -28,6 +28,7 @@ import {
  */
 import {
   telemetryCheckboxSelector,
+  videoCacheCheckboxSelector,
   videoOptimizationCheckboxSelector,
 } from '../../../utils';
 
@@ -38,8 +39,8 @@ describe('Editor User', () => {
   beforeEach(async () => {
     await visitSettings();
 
-    await disableCheckbox(telemetryCheckboxSelector);
-    await disableCheckbox(videoOptimizationCheckboxSelector);
+    await enableCheckbox(telemetryCheckboxSelector);
+    await enableCheckbox(videoOptimizationCheckboxSelector);
   });
 
   afterEach(async () => {
@@ -70,5 +71,9 @@ describe('Editor User', () => {
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:not(:checked)`
     );
+  });
+
+  it('should not give me the ability to see other settings', async () => {
+    await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import {
+  disableCheckbox,
+  enableCheckbox,
+  visitSettings,
+  withUser,
+} from '@web-stories-wp/e2e-test-utils';
+/**
+ * Internal dependencies
+ */
+import {
+  telemetryCheckboxSelector,
+  videoOptimizationCheckboxSelector,
+} from '../../../utils';
+
+describe('Editor User', () => {
+  // eslint-disable-next-line jest/require-hook
+  withUser('editor', 'password');
+
+  beforeEach(async () => {
+    await visitSettings();
+
+    await disableCheckbox(telemetryCheckboxSelector);
+    await disableCheckbox(videoOptimizationCheckboxSelector);
+  });
+
+  afterEach(async () => {
+    await visitSettings();
+
+    await enableCheckbox(telemetryCheckboxSelector);
+    await enableCheckbox(videoOptimizationCheckboxSelector);
+  });
+
+  it('should give me the ability to upload publisher logos', async () => {
+    // verify no publisher logos are shown
+    await expect(page).not.toMatchElement(
+      '[data-testid="publisher-logos-container"]'
+    );
+  });
+
+  it('should give me the ability to see and update the telemetry checkbox', async () => {
+    await disableCheckbox(telemetryCheckboxSelector);
+
+    await expect(page).toMatchElement(
+      `${telemetryCheckboxSelector}:not(:checked)`
+    );
+  });
+
+  it('should give me the ability to see and update the video optimization checkbox', async () => {
+    await disableCheckbox(videoOptimizationCheckboxSelector);
+
+    await expect(page).toMatchElement(
+      `${videoOptimizationCheckboxSelector}:not(:checked)`
+    );
+  });
+});

--- a/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
@@ -50,14 +50,14 @@ describe('Editor User', () => {
     await enableCheckbox(videoOptimizationCheckboxSelector);
   });
 
-  it('should give me the ability to upload publisher logos', async () => {
+  it('should let me upload publisher logos', async () => {
     // verify no publisher logos are shown
     await expect(page).not.toMatchElement(
       '[data-testid="publisher-logos-container"]'
     );
   });
 
-  it('should give me the ability to see and update the telemetry checkbox', async () => {
+  it('should let me see and update the telemetry checkbox', async () => {
     await disableCheckbox(telemetryCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -65,7 +65,7 @@ describe('Editor User', () => {
     );
   });
 
-  it('should give me the ability to see and update the video optimization checkbox', async () => {
+  it('should let me see and update the video optimization checkbox', async () => {
     await disableCheckbox(videoOptimizationCheckboxSelector);
 
     await expect(page).toMatchElement(
@@ -73,7 +73,7 @@ describe('Editor User', () => {
     );
   });
 
-  it('should not give me the ability to see other settings', async () => {
+  it('should not let me see other settings', async () => {
     await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
@@ -55,18 +55,12 @@ describe('Editor User', () => {
     // verify that the telemetry checkbox can be changed
     await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${telemetryCheckboxSelector}:not(:checked)`
-    );
 
     // verify that the video optimization checkbox can be changed
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:checked`
     );
     await disableCheckbox(videoOptimizationCheckboxSelector);
-    await expect(page).toMatchElement(
-      `${videoOptimizationCheckboxSelector}:not(:checked)`
-    );
 
     // verify no other settings are showing
     await expect(page).not.toMatchElement(

--- a/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
@@ -48,7 +48,7 @@ describe('Editor User', () => {
     await visitSettings();
 
     await disableCheckbox(telemetryCheckboxSelector);
-    await disableCheckbox(videoOptimizationCheckboxSelector);
+    await enableCheckbox(videoOptimizationCheckboxSelector);
   });
 
   it('should only let me see and update the telemetry and video optimization settings', async () => {

--- a/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
@@ -47,8 +47,8 @@ describe('Editor User', () => {
   afterEach(async () => {
     await visitSettings();
 
-    await enableCheckbox(telemetryCheckboxSelector);
-    await enableCheckbox(videoOptimizationCheckboxSelector);
+    await disableCheckbox(telemetryCheckboxSelector);
+    await disableCheckbox(videoOptimizationCheckboxSelector);
   });
 
   it('should only let me see and update the telemetry and video optimization settings', async () => {

--- a/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/editorUser.js
@@ -27,6 +27,7 @@ import {
  * Internal dependencies
  */
 import {
+  monetizationDropdownSelector,
   telemetryCheckboxSelector,
   videoCacheCheckboxSelector,
   videoOptimizationCheckboxSelector,
@@ -50,30 +51,28 @@ describe('Editor User', () => {
     await enableCheckbox(videoOptimizationCheckboxSelector);
   });
 
-  it('should let me upload publisher logos', async () => {
-    // verify no publisher logos are shown
-    await expect(page).not.toMatchElement(
-      '[data-testid="publisher-logos-container"]'
-    );
-  });
-
-  it('should let me see and update the telemetry checkbox', async () => {
+  it('should only let me see and update the telemetry and video optimization settings', async () => {
+    // verify that the telemetry checkbox can be changed
+    await expect(page).toMatchElement(`${telemetryCheckboxSelector}:checked`);
     await disableCheckbox(telemetryCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${telemetryCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should let me see and update the video optimization checkbox', async () => {
+    // verify that the video optimization checkbox can be changed
+    await expect(page).toMatchElement(
+      `${videoOptimizationCheckboxSelector}:checked`
+    );
     await disableCheckbox(videoOptimizationCheckboxSelector);
-
     await expect(page).toMatchElement(
       `${videoOptimizationCheckboxSelector}:not(:checked)`
     );
-  });
 
-  it('should not let me see other settings', async () => {
+    // verify no other settings are showing
+    await expect(page).not.toMatchElement(
+      '[data-testid="publisher-logos-container"]'
+    );
+    await expect(page).not.toMatchElement(monetizationDropdownSelector);
     await expect(page).not.toMatchElement(videoCacheCheckboxSelector);
   });
 });

--- a/packages/e2e-tests/src/specs/dashboard/settings/publisherLogo.js
+++ b/packages/e2e-tests/src/specs/dashboard/settings/publisherLogo.js
@@ -22,7 +22,6 @@ import {
   uploadPublisherLogo,
   visitSettings,
   withExperimentalFeatures,
-  withUser,
 } from '@web-stories-wp/e2e-test-utils';
 
 const ERROR_TEXT =
@@ -112,56 +111,5 @@ describe('Publisher logo', () => {
 
     uploadedFiles.push(logoOneName);
     uploadedFiles.push(logoTwoName);
-  });
-
-  it('should give me the ability to upload publisher logos', async () => {
-    await visitSettings();
-
-    // verify no publisher logos are shown
-    await expect(page).toMatchElement(
-      '[data-testid="publisher-logos-container"]'
-    );
-  });
-
-  describe('editor user', () => {
-    // eslint-disable-next-line jest/require-hook
-    withUser('editor', 'password');
-
-    it('should not give me the ability to upload publisher logos', async () => {
-      await visitSettings();
-
-      // verify no publisher logos are shown
-      await expect(page).not.toMatchElement(
-        '[data-testid="publisher-logos-container"]'
-      );
-    });
-  });
-
-  describe('author user', () => {
-    // eslint-disable-next-line jest/require-hook
-    withUser('author', 'password');
-
-    it('should not give me the ability to upload publisher logos', async () => {
-      await visitSettings();
-
-      // verify no publisher logos are shown
-      await expect(page).not.toMatchElement(
-        '[data-testid="publisher-logos-container"]'
-      );
-    });
-  });
-
-  describe('contributor user', () => {
-    // eslint-disable-next-line jest/require-hook
-    withUser('contributor', 'password');
-
-    it('should not give me the ability to upload publisher logos', async () => {
-      await visitSettings();
-
-      // verify no publisher logos are shown
-      await expect(page).not.toMatchElement(
-        '[data-testid="publisher-logos-container"]'
-      );
-    });
   });
 });

--- a/packages/e2e-tests/src/utils/constants.js
+++ b/packages/e2e-tests/src/utils/constants.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const telemetryCheckboxSelector =
+  'input[data-testid="telemetry-settings-checkbox"]';
+export const videoOptimizationCheckboxSelector =
+  'input[data-testid="media-optimization-settings-checkbox"]';

--- a/packages/e2e-tests/src/utils/constants.js
+++ b/packages/e2e-tests/src/utils/constants.js
@@ -18,3 +18,5 @@ export const telemetryCheckboxSelector =
   'input[data-testid="telemetry-settings-checkbox"]';
 export const videoOptimizationCheckboxSelector =
   'input[data-testid="media-optimization-settings-checkbox"]';
+export const videoCacheCheckboxSelector =
+  'input[data-testid="video-cache-settings-checkbox"]';

--- a/packages/e2e-tests/src/utils/constants.js
+++ b/packages/e2e-tests/src/utils/constants.js
@@ -14,9 +14,14 @@
  * limitations under the License.
  */
 
+export const monetizationDropdownSelector =
+  'button[aria-label="Monetization type"]';
+
 export const telemetryCheckboxSelector =
   'input[data-testid="telemetry-settings-checkbox"]';
+
 export const videoOptimizationCheckboxSelector =
   'input[data-testid="media-optimization-settings-checkbox"]';
+
 export const videoCacheCheckboxSelector =
   'input[data-testid="video-cache-settings-checkbox"]';

--- a/packages/e2e-tests/src/utils/index.js
+++ b/packages/e2e-tests/src/utils/index.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from './constants';


### PR DESCRIPTION
## Summary

Add e2e tests for non-admin users. 

## Relevant Technical Choices

Decided to go with existing publisher logo tests as a template. Non admin users may access the settings page but may not upload or delete publisher logos. Publisher logos are not displayed to the non-admin users.

These tests test two things:
1. That non-admin users may visit the settings page
2. That non-admin users are not shown publisher logos

## To-do

 n/a

## Reviews

### Does this PR have a security-related impact?

no

### Does this PR change what data or activity we track or use?

no

### Does this PR have a legal-related impact?

no

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #6638
