### PR TITLE
Static Site: Add Missing Page 11 Images for Baking Bread Template

### DIFF
--- a/public/static/main/images/templates/baking-bread-guide/posters/11.png
+++ b/public/static/main/images/templates/baking-bread-guide/posters/11.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d1922649b9a7aafe88d108c5e7b65136941b31034dd6d25b34ff9e24eb305f6e
+size 292669

--- a/public/static/main/images/templates/baking-bread-guide/posters/11.webp
+++ b/public/static/main/images/templates/baking-bread-guide/posters/11.webp
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2a4dd3e7361287df159d211065328e08b86362539b2f36bb211c3fe33bd1c200
-size 43116
+oid sha256:fcf5766608e9472bc7dd9e1c7f75fc51849ff670d62bf922b0ffb204c0751aa3
+size 77560

--- a/public/static/main/images/templates/baking-bread-guide/posters/11.webp
+++ b/public/static/main/images/templates/baking-bread-guide/posters/11.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2a4dd3e7361287df159d211065328e08b86362539b2f36bb211c3fe33bd1c200
+size 43116


### PR DESCRIPTION
## Context

#9289 introduces using the template screenshots as visual for default page templates in the editor. There's an e2e test for adding a custom page template that's angry about this missing image that's making the test error out. 

## Summary

Hopefully fixing that e2e test for 9289, in any case will fix this: 
<img width="387" alt="Screen Shot 2021-10-20 at 3 00 10 PM" src="https://user-images.githubusercontent.com/10720454/138178545-ae2716b3-b6e9-46db-835e-da712ebbd5eb.png">


## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

It's odd that the 11th page wasn't picked up and that all the other templates are fine 🤔 ? Warrants some investigation to prevent it going forward but the good news is that moving forward the template screenshots are going to get rendered in the editor here and so if they are missing we'll see that e2e test fail. 

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Partially addresses #9289
