### PR TITLE
Video Muting: Reuse existing resource if exists

### DIFF
--- a/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
@@ -89,11 +89,13 @@ const uploadMedia = (
 };
 
 const getOptimizedMediaById = jest.fn();
+const getMutedMediaById = jest.fn();
 
 function setup() {
   const apiContextValue = {
     actions: {
       getOptimizedMediaById,
+      getMutedMediaById,
     },
   };
   const storyContextValue = {
@@ -210,6 +212,28 @@ describe('useProcessMedia', () => {
   });
 
   describe('muteExistingVideo', () => {
+    it('should reuse already existing mute video', async () => {
+      getMutedMediaById.mockImplementationOnce(() => ({
+        id: 456,
+        src: 'http://www.google.com/foo-optimized.mp4',
+      }));
+
+      const { muteExistingVideo, uploadVideoPoster, updateMedia } = setup();
+      act(() => {
+        muteExistingVideo({
+          resource: {
+            src: 'http://www.google.com/foo.mov',
+            id: 123,
+            mimeType: 'video/quicktime',
+          },
+        });
+      });
+      await waitFor(() => {
+        expect(getMutedMediaById).toHaveBeenCalledWith(123);
+        expect(uploadVideoPoster).not.toHaveBeenCalled();
+        expect(updateMedia).not.toHaveBeenCalled();
+      });
+    });
     it('should mute video file', async () => {
       const { muteExistingVideo, uploadVideoPoster, updateMedia } = setup();
       act(() => {

--- a/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/test/useProcessMedia.js
@@ -212,7 +212,7 @@ describe('useProcessMedia', () => {
   });
 
   describe('muteExistingVideo', () => {
-    it('should reuse already existing mute video', async () => {
+    it('should reuse already existing muted video', async () => {
       getMutedMediaById.mockImplementationOnce(() => ({
         id: 456,
         src: 'http://www.google.com/foo-optimized.mp4',
@@ -234,6 +234,7 @@ describe('useProcessMedia', () => {
         expect(updateMedia).not.toHaveBeenCalled();
       });
     });
+
     it('should mute video file', async () => {
       const { muteExistingVideo, uploadVideoPoster, updateMedia } = setup();
       act(() => {

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -371,12 +371,12 @@ function useProcessMedia({
       })();
     },
     [
-      updateExistingElements,
       copyResourceData,
-      updateOldMutedObject,
-      uploadVideoPoster,
       getMutedMediaById,
+      updateExistingElements,
+      updateOldMutedObject,
       uploadMedia,
+      uploadVideoPoster,
     ]
   );
 

--- a/packages/story-editor/src/app/media/utils/useProcessMedia.js
+++ b/packages/story-editor/src/app/media/utils/useProcessMedia.js
@@ -37,7 +37,7 @@ function useProcessMedia({
   deleteMediaElement,
 }) {
   const {
-    actions: { getOptimizedMediaById },
+    actions: { getOptimizedMediaById, getMutedMediaById },
   } = useAPI();
   const { updateElementsByResourceId } = useStory((state) => ({
     updateElementsByResourceId: state.actions.updateElementsByResourceId,
@@ -325,7 +325,15 @@ function useProcessMedia({
         });
       };
 
-      const process = async () => {
+      (async () => {
+        const mutedResource = await getMutedMediaById(resourceId);
+
+        // This video was muted before, no need to mute it again.
+        if (mutedResource) {
+          updateExistingElements(resourceId, mutedResource);
+          return;
+        }
+
         let file = false;
         let posterFile = false;
         try {
@@ -360,15 +368,15 @@ function useProcessMedia({
           },
           posterFile,
         });
-      };
-      return process();
+      })();
     },
     [
-      copyResourceData,
-      uploadMedia,
-      uploadVideoPoster,
       updateExistingElements,
+      copyResourceData,
       updateOldMutedObject,
+      uploadVideoPoster,
+      getMutedMediaById,
+      uploadMedia,
     ]
   );
 

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -86,6 +86,28 @@ export function getMediaById(config, mediaId) {
 }
 
 /**
+ * Get the Muted variant of a given media resource.
+ *
+ * @param {Object} config Configuration object.
+ * @param {number} mediaId Media ID.
+ * @return {Promise<import('@web-stories-wp/media').Resource>} Media resource if found, null otherwise.
+ */
+export async function getMutedMediaById(config, mediaId) {
+  const path = addQueryArgs(`${config.api.media}${mediaId}/`, {
+    context: 'edit',
+    _fields: 'meta.web_stories_muted_id',
+  });
+
+  const result = await apiFetch({ path });
+
+  if (result?.meta?.web_stories_muted_id) {
+    return getMediaById(config, result.meta.web_stories_muted_id);
+  }
+
+  return null;
+}
+
+/**
  * Get the optimized variant of a given media resource.
  *
  * @param {Object} config Configuration object.

--- a/packages/wp-story-editor/src/api/media.js
+++ b/packages/wp-story-editor/src/api/media.js
@@ -86,7 +86,7 @@ export function getMediaById(config, mediaId) {
 }
 
 /**
- * Get the Muted variant of a given media resource.
+ * Get the muted variant of a given media resource.
  *
  * @param {Object} config Configuration object.
  * @param {number} mediaId Media ID.


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

When muting video, check to see if a muted version already exists, then use that instead of remuting. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Create a story. 
2. Insert a video into the canvas that has audio. 
3. Mute the video. 
4. Remove the element from the page. 
5. Reinsert the original video from the media library. 
6. Click mute again. 
7. See no new video is uploaded and the replacement hows straight away. 


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9385
