### PR TITLE
Block: Use actual `<img>` for `<amp-story-player>` poster

### DIFF
--- a/includes/Renderer/Story/Embed.php
+++ b/includes/Renderer/Story/Embed.php
@@ -121,9 +121,11 @@ class Embed {
 									loading="lazy"
 									data-amp-story-player-poster-img
 								/>
-							<?php } else {
+								<?php 
+							} else {
 								echo esc_html( $title );
-							} ?>
+							} 
+							?>
 						</a>
 					</amp-story-player>
 				</div>
@@ -150,9 +152,11 @@ class Embed {
 								loading="lazy"
 								data-amp-story-player-poster-img
 							/>
-						<?php } else {
+							<?php 
+						} else {
 							echo esc_html( $title );
-						} ?>
+						} 
+						?>
 					</a>
 				</amp-story-player>
 			</div>

--- a/includes/Renderer/Story/Embed.php
+++ b/includes/Renderer/Story/Embed.php
@@ -90,12 +90,7 @@ class Embed {
 		$class  = $args['class'];
 		$url    = $this->story->get_url();
 		$title  = $this->story->get_title();
-		$poster = ! empty( $this->story->get_poster_portrait() ) ? esc_url_raw( $this->story->get_poster_portrait() ) : '';
-
-		$amp_player_inner = esc_html( $title );
-		if ( $poster ) {
-			$amp_player_inner = sprintf( '<img src="%s" width="%d" height="%d" alt="%s" loading="lazy" data-amp-story-player-poster-img />', $poster, (int) $args['width'], (int) $args['height'], esc_attr( $title ) );
-		}
+		$poster = ! empty( $this->story->get_poster_portrait() ) ? $this->story->get_poster_portrait() : '';
 
 		$wrapper_style = sprintf(
 			'--aspect-ratio: %F; --width: %dpx; --height: %dpx',
@@ -117,7 +112,18 @@ class Embed {
 						height="<?php echo esc_attr( $args['height'] ); ?>"
 						layout="intrinsic">
 						<a href="<?php echo esc_url( $url ); ?>">
-							<?php echo $amp_player_inner; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							<?php if ( $poster ) { ?>
+								<img
+									src="<?php echo esc_url( $poster ); ?>"
+									width="<?php echo esc_attr( $args['width'] ); ?>"
+									height="<?php echo esc_attr( $args['height'] ); ?>"
+									alt="<?php echo esc_attr( $title ); ?>"
+									loading="lazy"
+									data-amp-story-player-poster-img
+								/>
+							<?php } else {
+								echo esc_html( $title );
+							} ?>
 						</a>
 					</amp-story-player>
 				</div>
@@ -135,7 +141,18 @@ class Embed {
 			<div class="wp-block-embed__wrapper" style="<?php echo esc_attr( $wrapper_style ); ?>">
 				<amp-story-player>
 					<a href="<?php echo esc_url( $url ); ?>">
-						<?php echo $amp_player_inner; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php if ( $poster ) { ?>
+							<img
+								src="<?php echo esc_url( $poster ); ?>"
+								width="<?php echo esc_attr( $args['width'] ); ?>"
+								height="<?php echo esc_attr( $args['height'] ); ?>"
+								alt="<?php echo esc_attr( $title ); ?>"
+								loading="lazy"
+								data-amp-story-player-poster-img
+							/>
+						<?php } else {
+							echo esc_html( $title );
+						} ?>
 					</a>
 				</amp-story-player>
 			</div>

--- a/includes/Renderer/Story/Embed.php
+++ b/includes/Renderer/Story/Embed.php
@@ -92,7 +92,11 @@ class Embed {
 		$title  = $this->story->get_title();
 		$poster = ! empty( $this->story->get_poster_portrait() ) ? esc_url_raw( $this->story->get_poster_portrait() ) : '';
 
-		$poster_style  = ! empty( $poster ) ? sprintf( '--story-player-poster: url(%s)', $poster ) : '';
+		$amp_player_inner = esc_html( $title );
+		if ( $poster ) {
+			$amp_player_inner = sprintf( '<img src="%s" width="%d" height="%d" alt="%s" loading="lazy" data-amp-story-player-poster-img />', $poster, (int) $args['width'], (int) $args['height'], esc_attr( $title ) );
+		}
+
 		$wrapper_style = sprintf(
 			'--aspect-ratio: %F; --width: %dpx; --height: %dpx',
 			0 !== $args['width'] ? $args['height'] / $args['width'] : 1,
@@ -112,10 +116,8 @@ class Embed {
 						width="<?php echo esc_attr( $args['width'] ); ?>"
 						height="<?php echo esc_attr( $args['height'] ); ?>"
 						layout="intrinsic">
-						<a
-							href="<?php echo esc_url( $url ); ?>"
-							style="<?php echo esc_attr( $poster_style ); ?>">
-							<?php echo esc_html( $title ); ?>
+						<a href="<?php echo esc_url( $url ); ?>">
+							<?php echo $amp_player_inner; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 						</a>
 					</amp-story-player>
 				</div>
@@ -132,10 +134,8 @@ class Embed {
 		<div class="<?php echo esc_attr( "$class web-stories-embed $align" ); ?>">
 			<div class="wp-block-embed__wrapper" style="<?php echo esc_attr( $wrapper_style ); ?>">
 				<amp-story-player>
-					<a
-						href="<?php echo esc_url( $url ); ?>"
-						style="<?php echo esc_attr( $poster_style ); ?>">
-						<?php echo esc_html( $title ); ?>
+					<a href="<?php echo esc_url( $url ); ?>">
+						<?php echo $amp_player_inner; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</a>
 				</amp-story-player>
 			</div>

--- a/packages/stories-block/src/block/block-types/single-story/storyPlayer.js
+++ b/packages/stories-block/src/block/block-types/single-story/storyPlayer.js
@@ -34,13 +34,18 @@ function StoryPlayer({ url, title, poster, width, height }, ref) {
       }}
       data-testid="amp-story-player"
     >
-      <a
-        href={url}
-        style={{
-          ['--story-player-poster']: poster ? `url('${poster}')` : undefined,
-        }}
-      >
-        {title}
+      <a href={url}>
+        {poster ? (
+          <img
+            alt={title}
+            src={poster}
+            width={width}
+            height={height}
+            data-amp-story-player-poster-img
+          />
+        ) : (
+          title
+        )}
       </a>
     </amp-story-player>
   );

--- a/packages/stories-block/src/block/block-types/single-story/test/storyPlayer.js
+++ b/packages/stories-block/src/block/block-types/single-story/test/storyPlayer.js
@@ -59,9 +59,12 @@ describe('StoryPlayer', () => {
       >
         <a
           href="https://preview.amp.dev/documentation/examples/introduction/stories_in_amp"
-          style="--story-player-poster: url('https://amp.dev/static/samples/img/story_dog2_portrait.jpg');"
         >
-          Stories in AMP
+          <img
+            alt="Stories in AMP"
+            data-amp-story-player-poster-img="true"
+            src="https://amp.dev/static/samples/img/story_dog2_portrait.jpg"
+          />
         </a>
       </amp-story-player>
     `);

--- a/tests/phpunit/integration/tests/Renderer/Story/Embed.php
+++ b/tests/phpunit/integration/tests/Renderer/Story/Embed.php
@@ -32,5 +32,36 @@ class Embed extends TestCase {
 		];
 		$render = $embed->render( $args );
 		$this->assertStringContainsString( 'test title', $render );
+		$this->assertStringNotContainsString( '<img', $render );
+	}
+
+	/**
+	 * @covers ::render
+	 */
+	public function test_render_with_image() {
+		$post = self::factory()->post->create_and_get(
+			[
+				'post_title'   => 'test title',
+				'post_type'    => \Google\Web_Stories\Story_Post_Type::POST_TYPE_SLUG,
+				'post_content' => '<html><head></head><body><amp-story></amp-story></body></html>',
+			]
+		);
+
+		$attachment_id = self::factory()->attachment->create_upload_object( WEB_STORIES_TEST_DATA_DIR . '/attachment.jpg', 0 );
+
+		set_post_thumbnail( $post->ID, $attachment_id );
+
+		$story = new \Google\Web_Stories\Model\Story();
+		$story->load_from_post( $post );
+		$assets = new \Google\Web_Stories\Assets();
+		$embed  = new \Google\Web_Stories\Renderer\Story\Embed( $story, $assets );
+		$args   = [
+			'align'  => 'none',
+			'height' => 600,
+			'width'  => 360,
+		];
+		$render = $embed->render( $args );
+		$this->assertStringContainsString( 'test title', $render );
+		$this->assertStringContainsString( '<img', $render );
 	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

## Summary

Instead of setting the poster as background image of the `<a>` within `<amp-story-player>`, we should use a proper `<img>` now that this is supported.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9391
