### PR TITLE
Output: Ensure `<amp-story-page-outlink>` is always the last child

### DIFF
--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -101,6 +101,7 @@ trait Sanitization_Utils {
 	 * Sanitizes <amp-story-page-outlink> elements to ensure they're always valid.
 	 *
 	 * Removes empty `cta-image` attributes.
+	 * Ensures the element is always the last child of <amp-story-page>.
 	 *
 	 * @since 1.13.0
 	 *
@@ -118,6 +119,13 @@ trait Sanitization_Utils {
 		foreach ( $outlink_elements as $element ) {
 			if ( ! $element->getAttribute( 'cta-image' ) ) {
 				$element->removeAttribute( 'cta-image' );
+			}
+
+			$amp_story_page = $element->parentNode;
+
+			if ( $element !== $amp_story_page->lastChild ) {
+				$amp_story_page->removeChild( $element );
+				$amp_story_page->appendChild( $element );
 			}
 		}
 	}

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -123,7 +123,7 @@ trait Sanitization_Utils {
 
 			$amp_story_page = $element->parentNode;
 
-			if ( $element !== $amp_story_page->lastChild ) {
+			if ( $amp_story_page && $element !== $amp_story_page->lastChild ) {
 				$amp_story_page->removeChild( $element );
 				$amp_story_page->appendChild( $element );
 			}

--- a/packages/story-editor/src/output/page.js
+++ b/packages/story-editor/src/output/page.js
@@ -156,6 +156,7 @@ function OutputPage({
           </div>
         </amp-story-grid-layer>
       )}
+      {/* <amp-story-page-outlink> needs to be the last child element */}
       {hasPageAttachment && (
         <amp-story-page-outlink
           layout="nodisplay"

--- a/packages/story-editor/src/output/page.js
+++ b/packages/story-editor/src/output/page.js
@@ -132,17 +132,6 @@ function OutputPage({
           </div>
         </amp-story-grid-layer>
       </StoryAnimation.Provider>
-      {hasPageAttachment && (
-        <amp-story-page-outlink
-          layout="nodisplay"
-          cta-image={page.pageAttachment.icon || undefined}
-          theme={page.pageAttachment.theme}
-        >
-          <a href={page.pageAttachment.url}>
-            {page.pageAttachment.ctaText || __('Learn more', 'web-stories')}
-          </a>
-        </amp-story-page-outlink>
-      )}
       {args.enableBetterCaptions && videoCaptions.length > 0 && (
         <amp-story-grid-layer
           template="vertical"
@@ -166,6 +155,17 @@ function OutputPage({
             </div>
           </div>
         </amp-story-grid-layer>
+      )}
+      {hasPageAttachment && (
+        <amp-story-page-outlink
+          layout="nodisplay"
+          cta-image={page.pageAttachment.icon || undefined}
+          theme={page.pageAttachment.theme}
+        >
+          <a href={page.pageAttachment.url}>
+            {page.pageAttachment.ctaText || __('Learn more', 'web-stories')}
+          </a>
+        </amp-story-page-outlink>
       )}
     </amp-story-page>
   );

--- a/packages/story-editor/src/output/test/page.js
+++ b/packages/story-editor/src/output/test/page.js
@@ -692,7 +692,7 @@ describe('Page output', () => {
       expect(content).toContain('http://shouldoutput.com');
     });
 
-    it('should print page attachment as the last child element', async () => {
+    it('should print page attachment as the last child element', () => {
       const props = {
         id: '123',
         backgroundColor: { type: 'solid', color: { r: 255, g: 255, b: 255 } },

--- a/packages/story-editor/src/output/test/page.js
+++ b/packages/story-editor/src/output/test/page.js
@@ -691,6 +691,68 @@ describe('Page output', () => {
       expect(content).toContain('Hello, link');
       expect(content).toContain('http://shouldoutput.com');
     });
+
+    it('should print page attachment as the last child element', async () => {
+      const props = {
+        id: '123',
+        backgroundColor: { type: 'solid', color: { r: 255, g: 255, b: 255 } },
+        page: {
+          id: '123',
+          pageAttachment: {
+            url: 'http://example.com',
+            ctaText: 'Click me!',
+          },
+          animations: [],
+          elements: [
+            {
+              id: 'baz',
+              type: 'video',
+              mimeType: 'video/mp4',
+              scale: 1,
+              origRatio: 9 / 16,
+              x: 50,
+              y: 100,
+              height: 1920,
+              width: 1080,
+              rotationAngle: 0,
+              loop: false,
+              resource: {
+                type: 'video',
+                mimeType: 'video/mp4',
+                id: 123,
+                src: 'https://example.com/video.mp4',
+                poster: 'https://example.com/poster.png',
+                height: 1920,
+                width: 1080,
+                length: 99,
+              },
+              tracks: [
+                {
+                  track: 'https://example.com/track.vtt',
+                  trackId: 123,
+                  trackName: 'track.vtt',
+                  id: 'rersd-fdfd-fdfd-fdfd',
+                  srcLang: '',
+                  label: '',
+                  kind: 'captions',
+                },
+              ],
+            },
+          ],
+        },
+        autoAdvance: true,
+        defaultPageDuration: 11,
+        args: {
+          enableBetterCaptions: true,
+        },
+      };
+
+      const { container } = render(<PageOutput {...props} />);
+      const page = container.querySelector('amp-story-page');
+      const pageOutlink = container.querySelector('amp-story-page-outlink');
+      expect(pageOutlink).toBeInTheDocument();
+      expect(page.lastChild).toBe(pageOutlink);
+    });
   });
 
   describe('background color', () => {

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -421,4 +421,22 @@ class Story_Sanitizer extends TestCase {
 
 		$this->assertStringContainsString( '<amp-story-page-outlink layout="nodisplay">', $actual );
 	}
+
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::sanitize_amp_story_page_outlink
+	 */
+	public function test_sanitize_amp_story_page_outlink_element_order() {
+		$source = '<html><head></head><body><amp-story><amp-story-page><amp-story-page-outlink layout="nodisplay" cta-image=""><a href="https://www.bonappeteach.com/smoked-apple-cider/" target="_blank" rel="noreferrer">Get The Recipe!</a></amp-story-page-outlink><amp-story-grid-layer></amp-story-grid-layer></amp-story-page></amp-story></body></html>';
+
+		$args = [
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertStringContainsString( '</amp-story-page-outlink></amp-story-page>', $actual );
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The new captions feature currently prints captions as the last child of `<amp-story-page>`, which causes AMP validation errors.

## Summary

<!-- A brief description of what this PR does. -->

This PR changes the story markup generation to ensure <amp-story-page-outlink>` is always the last child of `<amp-story-page>`.

## Relevant Technical Choices

<!-- Please describe your changes. -->

Adds a PHP sanitizer to fix existing stories.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add page attachment and video with captions on the same page
1. Validate story
2. Don't see validation error for `amp-story-page-outlink`


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9513
