### PR TITLE
Editor: Always add `crossorign` attribute to external resources

### DIFF
--- a/includes/Admin/Cross_Origin_Isolation.php
+++ b/includes/Admin/Cross_Origin_Isolation.php
@@ -40,8 +40,26 @@ use Google\Web_Stories\User\Preferences;
  *
  * @package Google\Web_Stories
  */
-class Cross_Origin_Isolation extends Service_Base implements Conditional, HasRequirements {
+class Cross_Origin_Isolation extends Service_Base implements HasRequirements {
 	use Screen;
+
+	/**
+	 * Preferences instance.
+	 *
+	 * @var Preferences Preferences instance.
+	 */
+	private $preferences;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.14.0
+	 *
+	 * @param Preferences $preferences Preferences instance.
+	 */
+	public function __construct( Preferences $preferences ) {
+		$this->preferences = $preferences;
+	}
 
 	/**
 	 * Init
@@ -84,13 +102,22 @@ class Cross_Origin_Isolation extends Service_Base implements Conditional, HasReq
 	}
 
 	/**
-	 * Check whether the conditional object is currently needed.
+	 * Determines whether "full" cross-origin isolation is needed.
 	 *
-	 * @since 1.6.0
+	 * By default, `crossorigin="anonymous"` attributes are added to all external
+	 * resources to make sure they can be accessed programmatically (e.g. by html-to-image).
+	 *
+	 * However, actual cross-origin isolation by sending COOP and COEP headers is only
+	 * needed when video optimization is enabled
+	 *
+	 * @link https://github.com/google/web-stories-wp/issues/9327
+	 * @link https://web.dev/coop-coep/
+	 *
+	 * @since 1.14.0
 	 *
 	 * @return bool Whether the conditional object is needed.
 	 */
-	public static function is_needed(): bool {
+	private function needs_isolation(): bool {
 		$user_id = get_current_user_id();
 		if ( ! $user_id ) {
 			return false;
@@ -101,17 +128,13 @@ class Cross_Origin_Isolation extends Service_Base implements Conditional, HasReq
 			return false;
 		}
 
-		$user_preferences = Services::get( 'user_preferences' );
-
 		return rest_sanitize_boolean(
-			$user_preferences->get_preference( $user_id, $user_preferences::MEDIA_OPTIMIZATION_META_KEY )
+			$this->preferences->get_preference( $user_id, $this->preferences::MEDIA_OPTIMIZATION_META_KEY )
 		);
 	}
 
 	/**
 	 * Get the list of service IDs required for this service to be registered.
-	 *
-	 * Needed because the service is used in the static `is_needed()` method.
 	 *
 	 * @since 1.12.0
 	 *
@@ -122,15 +145,17 @@ class Cross_Origin_Isolation extends Service_Base implements Conditional, HasReq
 	}
 
 	/**
-	 * Start output buffer and add headers.
+	 * Start output buffer to add headers and `crossorigin` attribute everywhere.
 	 *
 	 * @since 1.6.0
 	 *
 	 * @return void
 	 */
 	public function admin_header() {
-		header( 'Cross-Origin-Opener-Policy: same-origin' );
-		header( 'Cross-Origin-Embedder-Policy: require-corp' );
+		if ( $this->needs_isolation() ) {
+			header( 'Cross-Origin-Opener-Policy: same-origin' );
+			header( 'Cross-Origin-Embedder-Policy: require-corp' );
+		}
 
 		ob_start( [ $this, 'replace_in_dom' ] );
 	}

--- a/packages/e2e-tests/src/config/bootstrap.js
+++ b/packages/e2e-tests/src/config/bootstrap.js
@@ -89,11 +89,6 @@ const ALLOWED_ERROR_MESSAGES = [
 
   // Another Firefox warning.
   'Layout was forced before the page was fully loaded',
-
-  // @todo Fix issues, see https://github.com/google/web-stories-wp/issues/9327
-  'Error inlining remote css file SecurityError',
-  'Error loading remote stylesheet SecurityError',
-  'Error while reading CSS rules from https://fonts.googleapis.com',
 ];
 
 export function addAllowedErrorMessage(message) {

--- a/tests/phpunit/integration/tests/Admin/Cross_Origin_Isolation.php
+++ b/tests/phpunit/integration/tests/Admin/Cross_Origin_Isolation.php
@@ -88,49 +88,59 @@ class Cross_Origin_Isolation extends DependencyInjectedTestCase {
 	}
 
 	/**
-	 * @covers ::is_needed
+	 * @covers ::needs_isolation
 	 */
-	public function test_is_needed() {
+	public function test_needs_isolation() {
 		wp_set_current_user( $this->admin_id );
 		update_user_meta( $this->admin_id, \Google\Web_Stories\User\Preferences::MEDIA_OPTIMIZATION_META_KEY, true );
 
-		$this->assertTrue( \Google\Web_Stories\Admin\Cross_Origin_Isolation::is_needed() );
+		$actual = $this->call_private_method( $this->instance, 'needs_isolation' );
+
+		$this->assertTrue( $actual );
 	}
 
 	/**
-	 * @covers ::is_needed
+	 * @covers ::needs_isolation
 	 */
-	public function test_is_needed_default_user_meta_value() {
+	public function test_needs_isolation_default_user_meta_value() {
 		wp_set_current_user( $this->admin_id );
 
-		$this->assertTrue( \Google\Web_Stories\Admin\Cross_Origin_Isolation::is_needed() );
+		$actual = $this->call_private_method( $this->instance, 'needs_isolation' );
+
+		$this->assertTrue( $actual );
 	}
 
 	/**
-	 * @covers ::is_needed
+	 * @covers ::needs_isolation
 	 */
-	public function test_is_needed_no_user() {
-		$this->assertFalse( \Google\Web_Stories\Admin\Cross_Origin_Isolation::is_needed() );
+	public function test_needs_isolation_no_user() {
+		$actual = $this->call_private_method( $this->instance, 'needs_isolation' );
+
+		$this->assertFalse( $actual );
 	}
 
 	/**
-	 * @covers ::is_needed
+	 * @covers ::needs_isolation
 	 */
-	public function test_is_needed_opt_out() {
+	public function test_needs_isolation_opt_out() {
 		wp_set_current_user( $this->admin_id );
 		update_user_meta( $this->admin_id, \Google\Web_Stories\User\Preferences::MEDIA_OPTIMIZATION_META_KEY, false );
 
-		$this->assertFalse( \Google\Web_Stories\Admin\Cross_Origin_Isolation::is_needed() );
+		$actual = $this->call_private_method( $this->instance, 'needs_isolation' );
+
+		$this->assertFalse( $actual );
 	}
 
 	/**
-	 * @covers ::is_needed
+	 * @covers ::needs_isolation
 	 */
-	public function test_is_needed_no_upload_caps() {
+	public function test_needs_isolation_no_upload_caps() {
 		wp_set_current_user( $this->contributor_id );
 		update_user_meta( $this->contributor_id, \Google\Web_Stories\User\Preferences::MEDIA_OPTIMIZATION_META_KEY, true );
 
-		$this->assertFalse( \Google\Web_Stories\Admin\Cross_Origin_Isolation::is_needed() );
+		$actual = $this->call_private_method( $this->instance, 'needs_isolation' );
+
+		$this->assertFalse( $actual );
 	}
 
 	/**


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Video optimization / ffmpeg.wasm requires cross-origin isolation, which requires adding `crossorigin=anonymous` attributes to external assets.

We used to only do that when video optimization is enabled.

Now, `html-to-image` also requires setting this attribute because it needs to access external stylesheets.

## Summary

<!-- A brief description of what this PR does. -->

This PR changes the `Cross_Origin_Isolation` class so that the `crossorigin` attribute is always set.

The COOP and COEP headers continue to be only set when video optimization is enabled.

## Relevant Technical Choices

<!-- Please describe your changes. -->

* Un-ignores error messages because they should no longer occur.

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->
No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->
No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9327
