### PR TITLE
Video Captions: Enable by default

### DIFF
--- a/includes/Experiments.php
+++ b/includes/Experiments.php
@@ -391,6 +391,7 @@ class Experiments extends Service_Base implements HasRequirements {
 				'label'       => __( 'Video Captions', 'web-stories' ),
 				'description' => __( 'Improve video captions appearance when viewing stories', 'web-stories' ),
 				'group'       => 'general',
+				'default'     => true,
 			],
 		];
 	}


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

It's time to improve the video captions appearance.

## Summary

<!-- A brief description of what this PR does. -->

This PR enables the new video captions appearance by default ahead of the planned 1.14.0 release.

## Relevant Technical Choices

<!-- Please describe your changes. -->

N/A

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

See #9043 for context

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

See #9043 for context

This PR can be tested by following these steps:

1. Enable the video captions experiment
1. Create a story with 1 or more videos
1. Upload captions for the video(s)
1. Add some other elements on layers above the video(s)
1. Preview story and verify that captions are displayed correctly and on top of all other elements on the page and within the safe zone



## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9216 
