### PR TITLE
Sanitization: Remove images referencing grid placeholder

### DIFF
--- a/includes/AMP/Integration/AMP_Story_Sanitizer.php
+++ b/includes/AMP/Integration/AMP_Story_Sanitizer.php
@@ -59,5 +59,6 @@ class AMP_Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->remove_blob_urls( $this->dom );
 		$this->sanitize_srcset( $this->dom );
 		$this->sanitize_amp_story_page_outlink( $this->dom );
+		$this->remove_page_template_placeholder_images( $this->dom );
 	}
 }

--- a/includes/AMP/Story_Sanitizer.php
+++ b/includes/AMP/Story_Sanitizer.php
@@ -57,5 +57,6 @@ class Story_Sanitizer extends AMP_Base_Sanitizer {
 		$this->remove_blob_urls( $this->dom );
 		$this->sanitize_srcset( $this->dom );
 		$this->sanitize_amp_story_page_outlink( $this->dom );
+		$this->remove_page_template_placeholder_images( $this->dom );
 	}
 }

--- a/includes/AMP/Traits/Sanitization_Utils.php
+++ b/includes/AMP/Traits/Sanitization_Utils.php
@@ -421,4 +421,33 @@ trait Sanitization_Utils {
 			$image->setAttribute( 'srcset', implode( ', ', $entries_by_widths ) );
 		}
 	}
+
+	/**
+	 * Remove images referencing the grid-placeholder.png file which has since been removed.
+	 *
+	 * @link https://github.com/google/web-stories-wp/issues/9530
+	 *
+	 * @since 1.14.0
+	 *
+	 * @param Document|AMP_Document $document Document instance.
+	 * @return void
+	 */
+	private function remove_page_template_placeholder_images( &$document ) {
+		$placeholder_img = 'assets/images/editor/grid-placeholder.png';
+
+		/**
+		 * List of <amp-img> elements.
+		 *
+		 * @var DOMElement[] $images Image elements.
+		 */
+		$images = $document->body->getElementsByTagName( 'amp-img' );
+
+		foreach ( $images as $image ) {
+			$src = $image->getAttribute( 'src' );
+
+			if ( $image->parentNode && false !== strpos( $src, $placeholder_img ) ) {
+				$image->parentNode->removeChild( $image );
+			}
+		}
+	}
 }

--- a/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
+++ b/tests/phpunit/unit/tests/AMP/Story_Sanitizer.php
@@ -439,4 +439,21 @@ class Story_Sanitizer extends TestCase {
 
 		$this->assertStringContainsString( '</amp-story-page-outlink></amp-story-page>', $actual );
 	}
+	/**
+	 * @covers \Google\Web_Stories\AMP\Traits\Sanitization_Utils::remove_page_template_placeholder_images
+	 */
+	public function test_remove_page_template_placeholder_images() {
+		$source = '<html><head></head><body><amp-img src="https://example.com/wp-content/plugins/web-stories/assets/images/editor/grid-placeholder.png" width="100" height="100"></amp-img></body></html>';
+
+		$args = [
+			'publisher_logo' => '',
+			'publisher'      => '',
+			'poster_images'  => [],
+			'video_cache'    => false,
+		];
+
+		$actual = $this->sanitize_and_get( $source, $args );
+
+		$this->assertStringNotContainsString( 'amp-img', $actual );
+	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

Some older stories could still be referencing `grid-placeholder.png`, despite the image being removed from the plugin. This can cause 404s and related issues with the player.

## Summary

<!-- A brief description of what this PR does. -->

This updates AMP sanitization to remove any images referencing the old grid placeholder image.

## Relevant Technical Choices

<!-- Please describe your changes. -->

N/A

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

N/A

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9530
