### PR TITLE
Decoupling: Remove `testUtils` export from `story-editor`

### DIFF
--- a/packages/story-editor/src/index.js
+++ b/packages/story-editor/src/index.js
@@ -28,7 +28,6 @@ export * from './app/api';
 export * from './components/header';
 export * from './app/currentUser';
 export * from './output';
-export * from './testUtils';
 
 export { default as getStoryPropsToSave } from './app/story/utils/getStoryPropsToSave';
 export { default as FontContext } from './app/font/context';

--- a/packages/wp-story-editor/src/components/postLock/test/postLock.js
+++ b/packages/wp-story-editor/src/components/postLock/test/postLock.js
@@ -21,11 +21,11 @@ import { FlagsProvider } from 'flagged';
 import { setAppElement } from '@web-stories-wp/design-system';
 import { screen, act, waitFor } from '@testing-library/react';
 import {
-  renderWithTheme,
   ConfigContext,
   StoryContext,
   CurrentUserContext,
 } from '@web-stories-wp/story-editor';
+import { renderWithTheme } from '@web-stories-wp/story-editor/src/testUtils';
 
 /**
  * Internal dependencies

--- a/packages/wp-story-editor/src/components/postPublishDialog/test/postPublishDialog.js
+++ b/packages/wp-story-editor/src/components/postPublishDialog/test/postPublishDialog.js
@@ -23,7 +23,8 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { setAppElement } from '@web-stories-wp/design-system';
-import { renderWithTheme, StoryContext } from '@web-stories-wp/story-editor';
+import { StoryContext } from '@web-stories-wp/story-editor';
+import { renderWithTheme } from '@web-stories-wp/story-editor/src/testUtils';
 
 /**
  * Internal dependencies

--- a/packages/wp-story-editor/src/components/statusCheck/test/statusCheck.js
+++ b/packages/wp-story-editor/src/components/statusCheck/test/statusCheck.js
@@ -22,7 +22,8 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import { setAppElement } from '@web-stories-wp/design-system';
-import { renderWithTheme, ConfigContext } from '@web-stories-wp/story-editor';
+import { ConfigContext } from '@web-stories-wp/story-editor';
+import { renderWithTheme } from '@web-stories-wp/story-editor/src/testUtils';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## Context

https://github.com/google/web-stories-wp/issues/9516

## Summary

Removes `testUtils` export from `story-editor` to prevent tests from getting bundled.

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9516
