### PR TITLE
Improve AMP plugin availability detection

### DIFF
--- a/includes/AMP/Output_Buffer.php
+++ b/includes/AMP/Output_Buffer.php
@@ -119,14 +119,24 @@ class Output_Buffer extends Service_Base implements Conditional {
 	/**
 	 * Check whether the conditional object is currently needed.
 	 *
+	 * If the AMP plugin is installed and available in a version >= than ours,
+	 * all sanitization and optimization should be delegated to the AMP plugin.
+	 * But ONLY if AMP logic has not been disabled through any of its available filters.
+	 *
 	 * @since 1.10.0
 	 *
 	 * @return bool Whether the conditional object is needed.
 	 */
 	public static function is_needed(): bool {
-		// If the AMP plugin is installed and available in a version >= than ours,
-		// all sanitization and optimization should be delegated to the AMP plugin.
-		return ! defined( '\AMP__VERSION' ) || ( defined( '\AMP__VERSION' ) && version_compare( \AMP__VERSION, WEBSTORIES_AMP_VERSION, '<' ) );
+		$current_post = get_post();
+
+		$has_old_amp_version = ! defined( '\AMP__VERSION' ) || ( defined( '\AMP__VERSION' ) && version_compare( \AMP__VERSION, WEBSTORIES_AMP_VERSION, '<' ) );
+		$amp_available       = function_exists( 'amp_is_available' ) && amp_is_available();
+		$amp_enabled         = function_exists( 'amp_is_enabled' ) && amp_is_enabled(); // Technically an internal method.
+		$amp_initialized     = did_action( 'amp_init' ) > 0;
+		$amp_supported_post  = function_exists( 'amp_is_post_supported' ) && amp_is_post_supported( $current_post->ID ?? 0 );
+
+		return $has_old_amp_version || ! $amp_available || ! $amp_enabled || ! $amp_initialized || ! $amp_supported_post;
 	}
 
 	/**

--- a/tests/phpunit/unit/tests/AMP/Output_Buffer.php
+++ b/tests/phpunit/unit/tests/AMP/Output_Buffer.php
@@ -18,11 +18,24 @@
 namespace Google\Web_Stories\Tests\Unit\AMP;
 
 use Google\Web_Stories\Tests\Unit\TestCase;
+use Brain\Monkey;
 
 /**
  * @coversDefaultClass \Google\Web_Stories\AMP\Output_Buffer
  */
 class Output_Buffer extends TestCase {
+	public function set_up() {
+		parent::set_up();
+
+		Monkey\Functions\stubs(
+			[
+				'get_post' => static function () {
+					return null;
+				},
+			]
+		);
+	}
+
 	/**
 	 * @covers ::is_needed
 	 */
@@ -47,7 +60,18 @@ class Output_Buffer extends TestCase {
 	 */
 	public function test_is_needed_amp_same_version() {
 		define( 'AMP__VERSION', WEBSTORIES_AMP_VERSION );
-		$this->assertFalse( \Google\Web_Stories\AMP\Output_Buffer::is_needed() );
+		$this->assertTrue( \Google\Web_Stories\AMP\Output_Buffer::is_needed() );
+	}
+
+	/**
+	 * @covers ::is_needed
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_needed_amp_same_version_did_amp_init() {
+		define( 'AMP__VERSION', WEBSTORIES_AMP_VERSION );
+		do_action( 'amp_init' );
+		$this->assertTrue( \Google\Web_Stories\AMP\Output_Buffer::is_needed() );
 	}
 
 	/**
@@ -57,6 +81,44 @@ class Output_Buffer extends TestCase {
 	 */
 	public function test_is_needed_amp_higher_version() {
 		define( 'AMP__VERSION', '99.9.9' );
+		$this->assertTrue( \Google\Web_Stories\AMP\Output_Buffer::is_needed() );
+	}
+
+	/**
+	 * @covers ::is_needed
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_needed_amp_higher_version_did_amp_init() {
+		define( 'AMP__VERSION', '99.9.9' );
+		do_action( 'amp_init' );
+		$this->assertTrue( \Google\Web_Stories\AMP\Output_Buffer::is_needed() );
+	}
+
+	/**
+	 * @covers ::is_needed
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_is_needed_amp_properly_initialized() {
+		define( 'AMP__VERSION', WEBSTORIES_AMP_VERSION );
+		do_action( 'amp_init' );
+
+		Monkey\Functions\stubs(
+			[
+				'get_post'              => static function () {
+					return null;
+				},
+				'amp_is_available'      => static function () {
+					return true; },
+				'amp_is_enabled'        => static function () {
+					return true; },
+				'amp_is_post_supported' => static function ( $post ) {
+					return true;
+				},
+			]
+		);
+
 		$this->assertFalse( \Google\Web_Stories\AMP\Output_Buffer::is_needed() );
 	}
 }


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

From what I've seen in some support requests, it looks like there are cases where neither our AMP sanitization nor the one built into the AMP plugin runs.

This might be caused by some other plugin or theme on the user's site disabling some of the AMP plugin's functionality. (don't know yet what the cause usually is).

Right now, we defer AMP sanitization to the plugin if it's installed. However, that doesn't mean it's actually running.

For example, if another plugin does something like `add_filter( 'amp_is_enabled', '__return_false' );`, our plugin would defer sanitization, but the AMP plugin would not do anything.

## Summary

<!-- A brief description of what this PR does. -->

This PR adds some further checks to verify whether the AMP plugin is actually going to sanitize the story or not, so that we will take over if necessary.

## Relevant Technical Choices

<!-- Please describe your changes. -->

* Uses `amp_is_enabled()` despite being marked as internal due to lack of alternatives

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

* Testing
* Maybe use different methods to detect AMP availability

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

N/A

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Add `add_filter( 'amp_is_enabled', '__return_false' );` somewhere in a plugin
2. Verify that a web story is still being properly sanitized


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

No

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

No

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

No

## Checklist

<!-- Check these after PR creation -->

- [ ] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #
