### PR TITLE
Library Tabs: change aria-label to title on svgs

### DIFF
--- a/packages/story-editor/src/components/library/karma/mediaTab.karma.js
+++ b/packages/story-editor/src/components/library/karma/mediaTab.karma.js
@@ -79,4 +79,11 @@ describe('Library Media Tab', () => {
       ).toBeDefined();
     });
   });
+  //todo: add axe for all tabs in libraryTabs.karma.js once the text tab is no longer a button within a button see issue #7365
+  describe('library Media tab should have no aXe accessibility violations', () => {
+    it('should pass accessibility', async () => {
+      const mediaTab = fixture.container.querySelector(`#library-tab-media`);
+      await expectAsync(mediaTab).toHaveNoViolations();
+    });
+  });
 });

--- a/packages/story-editor/src/components/library/panes/elements/elementsIcon.js
+++ b/packages/story-editor/src/components/library/panes/elements/elementsIcon.js
@@ -21,7 +21,7 @@ import { __ } from '@web-stories-wp/i18n';
 import { Icons } from '@web-stories-wp/design-system';
 
 function ElementsIcon() {
-  return <Icons.Box4 aria-label={__('Elements library', 'web-stories')} />;
+  return <Icons.Box4 title={__('Elements library', 'web-stories')} />;
 }
 
 export default ElementsIcon;

--- a/packages/story-editor/src/components/library/panes/media/local/mediaIcon.js
+++ b/packages/story-editor/src/components/library/panes/media/local/mediaIcon.js
@@ -21,7 +21,7 @@ import { __ } from '@web-stories-wp/i18n';
 import { Icons } from '@web-stories-wp/design-system';
 
 function MediaIcon() {
-  return <Icons.ArrowCloud aria-label={__('Media Gallery', 'web-stories')} />;
+  return <Icons.ArrowCloud title={__('Media Gallery', 'web-stories')} />;
 }
 
 export default MediaIcon;

--- a/packages/story-editor/src/components/library/panes/media/media3p/media3pIcon.js
+++ b/packages/story-editor/src/components/library/panes/media/media3p/media3pIcon.js
@@ -21,12 +21,7 @@ import { __ } from '@web-stories-wp/i18n';
 import { Icons } from '@web-stories-wp/design-system';
 
 function Media3pIcon() {
-  return (
-    <Icons.Picture
-      alt={__('Explore Media', 'web-stories')}
-      title={__('Explore Media', 'web-stories')}
-    />
-  );
+  return <Icons.Picture title={__('Explore Media', 'web-stories')} />;
 }
 
 export default Media3pIcon;

--- a/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesIcon.js
+++ b/packages/story-editor/src/components/library/panes/pageTemplates/pageTemplatesIcon.js
@@ -22,9 +22,7 @@ import { Icons } from '@web-stories-wp/design-system';
 
 function PageTemplatesIcon() {
   return (
-    <Icons.Box4Alternate
-      aria-label={__('Page templates library', 'web-stories')}
-    />
+    <Icons.Box4Alternate title={__('Page templates library', 'web-stories')} />
   );
 }
 

--- a/packages/story-editor/src/components/library/panes/shapes/shapesIcon.js
+++ b/packages/story-editor/src/components/library/panes/shapes/shapesIcon.js
@@ -21,7 +21,7 @@ import { __ } from '@web-stories-wp/i18n';
 import { Icons } from '@web-stories-wp/design-system';
 
 function ShapesIcon() {
-  return <Icons.Shapes aria-label={__('Shapes library', 'web-stories')} />;
+  return <Icons.Shapes title={__('Shapes library', 'web-stories')} />;
 }
 
 export default ShapesIcon;

--- a/packages/story-editor/src/components/library/panes/text/textIcon.js
+++ b/packages/story-editor/src/components/library/panes/text/textIcon.js
@@ -104,6 +104,7 @@ function TextIcon(props) {
         />
       </IconWrapper>
       <QuickAction
+        aria-label={__('Add new text element', 'web-stories')}
         onClick={handleAddText}
         tabIndex={isActive ? 0 : -1}
         onFocus={() => setIsFocusingQuick(true)}

--- a/packages/story-editor/src/components/library/panes/text/textIcon.js
+++ b/packages/story-editor/src/components/library/panes/text/textIcon.js
@@ -99,19 +99,21 @@ function TextIcon(props) {
         <AnimatedTextIcon
           id="text-tab-icon"
           isSecondary={isHoveringQuick || isFocusingQuick}
-          aria-label={__('Text library', 'web-stories')}
+          title={__('Text library', 'web-stories')}
           onPointerOver={() => setIsHoveringQuick(false)}
         />
       </IconWrapper>
       <QuickAction
-        aria-label={__('Add new text element', 'web-stories')}
         onClick={handleAddText}
         tabIndex={isActive ? 0 : -1}
         onFocus={() => setIsFocusingQuick(true)}
         onBlur={() => setIsFocusingQuick(false)}
         onPointerOver={() => setIsHoveringQuick(true)}
       >
-        <AnimatedTextAddIcon isPrimary={isHoveringQuick || isFocusingQuick} />
+        <AnimatedTextAddIcon
+          title={__('Add new text element', 'web-stories')}
+          isPrimary={isHoveringQuick || isFocusingQuick}
+        />
       </QuickAction>
     </TextIconContainer>
   );

--- a/packages/story-editor/src/components/library/test/text/textTab.js
+++ b/packages/story-editor/src/components/library/test/text/textTab.js
@@ -69,7 +69,7 @@ describe('TextTab', () => {
     );
 
     act(() => {
-      fireEvent.click(screen.getByLabelText('Add new text element'));
+      fireEvent.click(screen.getByTitle('Add new text element'));
     });
 
     await waitFor(() => expect(insertElement).toHaveBeenCalledTimes(1));


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->

The library tabs in the editor use aria-label attributes on the SVG icons. While some assistive technologies understand that, it's recommended to use <title> elements within the SVG.

## Summary

<!-- A brief description of what this PR does. -->

Replaced svg icons' `aria-label` attribute with the `title` attribute. 

## Relevant Technical Choices

<!-- Please describe your changes. -->

## To-do

<!-- A list of things that need to be addressed in this PR or follow-up changes. -->

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [x] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Open dev dev tool and inspect library tabs in the editor
2. Note the svgs' now have a title element instead of the aria-label attribute. 


## Reviews

### Does this PR have a security-related impact?
no

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #7573 
