### PR TITLE
Layers Panel: make icons darker on hover

### DIFF
--- a/packages/story-editor/src/components/panels/design/layer/layer.js
+++ b/packages/story-editor/src/components/panels/design/layer/layer.js
@@ -119,7 +119,7 @@ const LayerButton = styled(Button).attrs({
           theme.colors.interactiveBg.secondaryPress,
           0
         )};
-        --selected-hover-color: ${theme.colors.interactiveFg.brandHover};
+        --selected-hover-color: ${theme.colors.interactiveBg.tertiaryHover};
       }
     `}
 


### PR DESCRIPTION
## Context

<!-- What do we want to achieve with this PR? Why did we write this code? -->
Layer Panel: The hover color of the icons when a layer is selected is too dark.

## Summary

<!-- A brief description of what this PR does. -->
@agingoldseco would like gray 70 to be used 

## Relevant Technical Choices

<!-- Please describe your changes. -->


## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

1. Hover the trash can icon after selecting a layer within the layers panel. 
2. Notice it is no longer quite as dark as before


## Reviews
### New:
<img width="78" alt="Screen Shot 2021-10-29 at 1 32 26 PM" src="https://user-images.githubusercontent.com/1820266/139491981-c7af3c54-b73d-4e66-a780-cd4f7b8d304b.png">

### Old: 

<img width="95" alt="Screen Shot 2021-10-29 at 10 19 05 AM" src="https://user-images.githubusercontent.com/1820266/139491888-d82ab5dc-cc5f-4bc4-8aee-1ecb6dbeab69.png">
### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?
no

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?
no
<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it in ZenHub
- [x] I have tested this code to the best of my abilities
- [x] I have verified accessibility to the best of my abilities ([docs](https://github.com/google/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [x] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [x] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/google/web-stories-wp/tree/main/docs#testing))
- [x] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #9544 
