### PR TITLE
Rich Text: don't remove ordered lists

### DIFF
--- a/packages/rich-text/src/htmlManipulation.ts
+++ b/packages/rich-text/src/htmlManipulation.ts
@@ -123,6 +123,7 @@ export function sanitizeEditorHtml(html: string) {
           entities: [],
           maxNesting: 1,
           whitespacedCharacters: [],
+          blockTextRules: [],
         },
         editorState
       )


### PR DESCRIPTION
## Summary

<!-- A brief description of what this PR does. -->

Prevent text starting with numbered list patterns (e.g., "1. hello", "2. world") from being stripped in DisplayText preview mode, showing only "hello" and "world".

This PR prevents this default behavior caused by `draftjs-filters`

## User-facing changes

<!--
Please describe your changes.
Include before/after screenshots or a short video.
-->

## Testing Instructions

<!--
How can the changes in this PR be verified?
Please provide step-by-step instructions how to reproduce the issue, if applicable.
Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

<!-- ignore-task-list-start -->
- [ ] This is a non-user-facing change and requires no QA
<!-- ignore-task-list-end -->

This PR can be tested by following these steps:

Write something like 

```
1. hello
2. world
```

and then exit edit mode.

The numbers should still be visible.


## Reviews

### Does this PR have a security-related impact?

<!-- Examples: new APIs, changes to KSES, etc.  -->

### Does this PR change what data or activity we track or use?

<!-- Examples: changes to telemetry, new third-party APIs -->

### Does this PR have a legal-related impact?

<!-- Examples: new images with unknown sources, new production dependencies with incompatible licenses -->

## Checklist

<!-- Check these after PR creation -->

- [x] This PR addresses an existing issue and I have linked this PR to it
- [x] I have tested this code to the best of my abilities
- [ ] I have verified accessibility to the best of my abilities ([docs](https://github.com/googleforcreators/web-stories-wp/blob/main/docs/accessibility-testing.md))
- [ ] I have verified i18n and l10n (translation, right-to-left layout) to the best of my abilities
- [ ] This code is covered by automated tests (unit, integration, and/or e2e) to verify it works as intended ([docs](https://github.com/googleforcreators/web-stories-wp/tree/main/docs#testing))
- [ ] I have added documentation where necessary
- [x] I have added a matching `Type: XYZ` label to the PR

---

<!--
Please reference the issue(s) this PR addresses.
No URLs, just the issue numbers.
Use "Fixes #123" if it fixes an issue.

NOTE: One reference per line!

Example:

Fixes #123
Partially addresses #456
See #789
-->

Fixes #14092
